### PR TITLE
feat(manager,models): stream per-label notifications and refine progress metrics

### DIFF
--- a/manager/src/lib/Manager.ts
+++ b/manager/src/lib/Manager.ts
@@ -362,36 +362,48 @@ export default class Manager {
       return;
     }
 
-    // Filter triples: keep all NamedNode triples,
-    // and only keep literal triples with whitelisted predicates
-    const nnTriples = triples.filter((t) => typeof t.object === 'string');
+    // Separate triples: label/comment literals (for path extension preference) and all others
     const labelTriples = this.getLabelTriples(triples);
+    // All other triples: named nodes and non-label/comment literals (e.g., gloss)
+    const otherTriples = triples.filter(
+      (t) =>
+        !(
+          t.type === TripleType.LITERAL &&
+          (t.predicate === 'http://www.w3.org/2000/01/rdf-schema#label' ||
+            t.predicate === 'http://www.w3.org/2000/01/rdf-schema#comment')
+        )
+    );
 
     const source = (await Resource.findOne({
       url: sourceUrl
     })) as ResourceClass;
 
-    // add new resources
-    await Resource.addFromTriples([...nnTriples, ...labelTriples]);
+    // add new resources from all triples
+    await Resource.addFromTriples([...otherTriples, ...labelTriples]);
 
-    // Store all triples using unified upsertMany
-    log.info('Calling Triple.upsertMany with', nnTriples.length, 'triples');
-    const nnTripleResult = await Triple.upsertMany(source.url, nnTriples);
-    log.info('Triple.upsertMany result:', nnTripleResult);
+    // Store all triples: other triples (named nodes + non-label literals) and label triples separately
+    if (otherTriples.length > 0) {
+      log.info('Calling Triple.upsertMany with', otherTriples.length, 'other triples');
+      await Triple.upsertMany(source.url, otherTriples);
+    }
 
-    log.info('Calling Triple.upsertMany with', labelTriples.length, 'label triples');
-    const labelTripleResult = await Triple.upsertMany(source.url, labelTriples);
-    log.info('Triple.upsertMany result for label triples:', labelTripleResult);
+    if (labelTriples.length > 0) {
+      log.info('Calling Triple.upsertMany with', labelTriples.length, 'label triples');
+      await Triple.upsertMany(source.url, labelTriples);
+    }
 
     if (extendLabelsOnly) {
       log.info('Skipping extendPaths for headUrl:', source.url, 'because dontExtend flag is set');
-      const upsertedIds = labelTripleResult
-        .map((r) => Object.values(r.upsertedIds || {}))
-        .flat()
-        .filter((id): id is Types.ObjectId => id != null);
-      const labelTripleDocs = upsertedIds.length
-        ? ((await Triple.find({ _id: { $in: upsertedIds } })) as TripleDocument[])
-        : [];
+      // For label-only extension, fetch the label triples we just stored
+      const labelTripleDocs = await Triple.find({
+        subject: sourceUrl,
+        predicate: {
+          $in: [
+            'http://www.w3.org/2000/01/rdf-schema#label',
+            'http://www.w3.org/2000/01/rdf-schema#comment'
+          ]
+        }
+      });
       await extendPaths({ triples: labelTripleDocs });
       return;
     }
@@ -403,27 +415,41 @@ export default class Manager {
   }
 
   /**
-   * Returns literal triples with rdfs:label or rdfs:comment predicates that have language 'en'.
+   * Returns literal triples with rdfs:label or rdfs:comment predicates.
+   * For each subject: if any triples have language === 'en', only those are returned.
+   * Otherwise, only triples with no language tag are returned.
    * Returns them as SimpleTriple format for compatibility with the result type.
    */
   getLabelTriples(triples: SimpleTriple[]): SimpleLiteralTriple[] {
     const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
     const RDFS_COMMENT = 'http://www.w3.org/2000/01/rdf-schema#comment';
 
-    return triples
-      .filter((t): t is SimpleLiteralTriple => {
-        if (t.predicate !== RDFS_LABEL && t.predicate !== RDFS_COMMENT) return false;
-        const lit = t as SimpleLiteralTriple;
-        return lit.object.language === 'en';
-      })
-      .map(
-        (t): SimpleLiteralTriple => ({
-          subject: t.subject,
-          predicate: t.predicate,
-          type: TripleType.LITERAL,
-          object: t.object
-        })
-      );
+    // First, filter to only label/comment triples and group by subject
+    const bySubject = new Map<string, SimpleLiteralTriple[]>();
+
+    for (const t of triples) {
+      if (t.predicate !== RDFS_LABEL && t.predicate !== RDFS_COMMENT) continue;
+      const lit = t as SimpleLiteralTriple;
+      if (!bySubject.has(lit.subject)) {
+        bySubject.set(lit.subject, []);
+      }
+      bySubject.get(lit.subject)!.push(lit);
+    }
+
+    // For each subject, prefer English-labeled triples; fall back to tag-less only
+    const result: SimpleLiteralTriple[] = [];
+    for (const [, subjectTriples] of bySubject.entries()) {
+      const enTriples = subjectTriples.filter((t) => t.object.language === 'en');
+      if (enTriples.length > 0) {
+        result.push(...enTriples);
+      } else {
+        // No English triples; keep only those with no language tag (language == null)
+        const tagLess = subjectTriples.filter((t) => t.object.language == null);
+        result.push(...tagLess);
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/manager/src/lib/Manager.ts
+++ b/manager/src/lib/Manager.ts
@@ -16,7 +16,10 @@ import {
   type LiteralTripleDocument,
   HEAD_TYPE
 } from '@derzis/models';
-import { notifyLabelsFetched } from '@derzis/models/Process/process-notifications';
+import {
+  notifyLabelsFetched,
+  notifySingleLabelFetched
+} from '@derzis/models/Process/process-notifications';
 import {
   type JobResult,
   type RobotsCheckResult,
@@ -304,17 +307,9 @@ export default class Manager {
       return;
     }
 
-    // Check if all cardea labels with extend=false are done for this process
+    // Immediately notify Cardea for each label that is done (for cardea+extend=false)
     if (rl.source === 'cardea' && rl.extend === false) {
-      const remaining = await ResourceLabel.countDocuments({
-        pid: rl.pid,
-        status: 'new',
-        source: 'cardea',
-        extend: false
-      });
-      if (remaining === 0) {
-        await notifyLabelsFetched(rl.pid);
-      }
+      await notifySingleLabelFetched(rl.url, triples, rl.pid);
     }
   }
 

--- a/manager/src/routes/api/processes/[pid]/events/+server.ts
+++ b/manager/src/routes/api/processes/[pid]/events/+server.ts
@@ -30,13 +30,20 @@ export async function GET({ params }: RequestEvent) {
             return;
           }
 
-          const pathProgress = await getPathProgress(process);
-          const crawlRate = await getCrawlRate(process, 5);
-          const distinctHeads = await getDistinctPathHeadsRemaining(process);
+          const latestProcess = await Process.findOne({ pid: params.pid });
+          if (!latestProcess) {
+            isActive = false;
+            clearInterval(intervalId);
+            return;
+          }
+
+          const pathProgress = await getPathProgress(latestProcess);
+          const crawlRate = await getCrawlRate(latestProcess, 5);
+          const distinctHeads = await getDistinctPathHeadsRemaining(latestProcess);
 
           const event = {
             type: 'PROGRESS',
-            step: process.steps.length,
+            step: latestProcess.steps.length,
             paths: {
               done: pathProgress.done,
               remaining:

--- a/manager/src/routes/api/processes/[pid]/events/+server.ts
+++ b/manager/src/routes/api/processes/[pid]/events/+server.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { Process } from '@derzis/models';
-import { getPathProgress, getCrawlRate } from '@derzis/models';
+import { getPathProgress, getCrawlRate, getDistinctPathHeadsRemaining } from '@derzis/models';
 import type { RequestEvent } from './$types';
 
 const PROGRESS_INTERVAL_MS = 10000;
@@ -32,6 +32,7 @@ export async function GET({ params }: RequestEvent) {
 
           const pathProgress = await getPathProgress(process);
           const crawlRate = await getCrawlRate(process, 5);
+          const distinctHeads = await getDistinctPathHeadsRemaining(process);
 
           const event = {
             type: 'PROGRESS',
@@ -41,7 +42,8 @@ export async function GET({ params }: RequestEvent) {
               remaining:
                 pathProgress.remaining.unvisited +
                 pathProgress.remaining.crawling +
-                pathProgress.remaining.checking
+                pathProgress.remaining.checking,
+              distinctHeads
             },
             rate: crawlRate
           };

--- a/manager/src/routes/api/processes/[pid]/events/+server.ts
+++ b/manager/src/routes/api/processes/[pid]/events/+server.ts
@@ -45,7 +45,6 @@ export async function GET({ params }: RequestEvent) {
             type: 'PROGRESS',
             step: latestProcess.steps.length,
             paths: {
-              done: pathProgress.done,
               remaining:
                 pathProgress.remaining.unvisited +
                 pathProgress.remaining.crawling +

--- a/manager/src/routes/api/processes/[pid]/labels/+server.ts
+++ b/manager/src/routes/api/processes/[pid]/labels/+server.ts
@@ -1,5 +1,5 @@
 import { ResourceLabel } from '@derzis/models';
-import { getLabelDataForProcess } from '@derzis/models/Process/process-data';
+import { getLabelDataForProcess, getLabelDataForUrls } from '@derzis/models/Process/process-data';
 import { error, json } from '@sveltejs/kit';
 import type { RequestEvent } from './$types';
 
@@ -68,14 +68,16 @@ export async function POST({ params, request }: RequestEvent) {
   const { resources, source, extend } = body.data;
 
   if (!Array.isArray(resources) || resources.length === 0) {
-    return json({ ok: true, created: 0 });
+    return json({ ok: true, created: 0, labels: [] });
   }
 
   try {
     const resData = resources.map((url) => ({ pid, url, source, extend }));
     await ResourceLabel.upsertMany(resData);
 
-    return json({ ok: true, created: resData.length });
+    const existingDoneLabels = await getLabelDataForUrls(resources);
+
+    return json({ ok: true, created: resData.length, labels: existingDoneLabels });
   } catch (e) {
     return json({ ok: false, err: String(e) }, { status: 500 });
   }

--- a/manager/src/routes/processes/[pid]/+page.svelte
+++ b/manager/src/routes/processes/[pid]/+page.svelte
@@ -9,7 +9,7 @@
 
   let progress: {
     step: number;
-    paths: { done: number; remaining: number; distinctHeads: number };
+    paths: { remaining: number; distinctHeads: number };
     rate: number;
   } | null = null;
   let error: string | null = null;
@@ -130,7 +130,7 @@
     </div>
     <div>
       <strong>Step {progress.step}:</strong>
-      {progress.paths.done} paths done | {progress.paths.remaining} remaining |
+      {progress.paths.remaining} paths remaning |
       {progress.paths.distinctHeads} distinct path heads remaining |
       {progress.rate.toFixed(1)} resources/min
     </div>

--- a/manager/src/routes/processes/[pid]/+page.svelte
+++ b/manager/src/routes/processes/[pid]/+page.svelte
@@ -7,8 +7,11 @@
   import { HiSolidMagnifyingGlass } from 'svelte-icons-pack/hi';
   import { onMount, onDestroy } from 'svelte';
 
-  let progress: { step: number; paths: { done: number; remaining: number }; rate: number } | null =
-    null;
+  let progress: {
+    step: number;
+    paths: { done: number; remaining: number; distinctHeads: number };
+    rate: number;
+  } | null = null;
   let error: string | null = null;
   let eventSource: EventSource | null = null;
 
@@ -128,6 +131,7 @@
     <div>
       <strong>Step {progress.step}:</strong>
       {progress.paths.done} paths done | {progress.paths.remaining} remaining |
+      {progress.paths.distinctHeads} distinct path heads remaining |
       {progress.rate.toFixed(1)} resources/min
     </div>
   </Alert>

--- a/manager/src/routes/processes/[pid]/+page.svelte
+++ b/manager/src/routes/processes/[pid]/+page.svelte
@@ -121,10 +121,15 @@
 </header>
 
 {#if isRunning && progress}
-  <Alert color="info" class="mb-4">
-    <strong>Step {progress.step}:</strong>
-    {progress.paths.done} paths done | {progress.paths.remaining} remaining |
-    {progress.rate.toFixed(1)} resources/min
+  <Alert color="info" class="mb-4 d-flex align-items-center">
+    <div class="spinner-border spinner-border-sm me-2" role="status">
+      <span class="visually-hidden">Updating...</span>
+    </div>
+    <div>
+      <strong>Step {progress.step}:</strong>
+      {progress.paths.done} paths done | {progress.paths.remaining} remaining |
+      {progress.rate.toFixed(1)} resources/min
+    </div>
   </Alert>
 {:else if isRunning && error}
   <Alert color="warning" class="mb-4">{error}</Alert>

--- a/models/src/Path/EndpointPath.ts
+++ b/models/src/Path/EndpointPath.ts
@@ -441,6 +441,9 @@ function collectLiteralCandidates(
 ): Candidate[] {
   const candidates: Candidate[] = [];
 
+  const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
+  const RDFS_COMMENT = 'http://www.w3.org/2000/01/rdf-schema#comment';
+
   const literalTriples = triples
     .filter((t): t is LiteralTripleDocument => isLiteral(t))
     .filter((t) => this.isExtensionValid(t, urlHead));
@@ -453,7 +456,10 @@ function collectLiteralCandidates(
     });
 
     if (processedLiterals.has(literalKey)) {
-      procTriples.push({ id: t._id.toString(), type: TripleType.LITERAL });
+      // Only add rdfs:label and rdfs:comment to procTriples
+      if (t.predicate === RDFS_LABEL || t.predicate === RDFS_COMMENT) {
+        procTriples.push({ id: t._id.toString(), type: TripleType.LITERAL });
+      }
       continue;
     }
     processedLiterals.add(literalKey);
@@ -472,7 +478,10 @@ function collectLiteralCandidates(
     };
 
     candidates.push({ literalHead, distance, seedPaths });
-    procTriples.push({ id: t._id.toString(), type: TripleType.LITERAL });
+    // Only add rdfs:label and rdfs:comment to procTriples
+    if (t.predicate === RDFS_LABEL || t.predicate === RDFS_COMMENT) {
+      procTriples.push({ id: t._id.toString(), type: TripleType.LITERAL });
+    }
   }
 
   return candidates;

--- a/models/src/Path/TraversalPath.ts
+++ b/models/src/Path/TraversalPath.ts
@@ -359,6 +359,9 @@ export class TraversalPathClass extends PathClass {
       .filter((t): t is LiteralTripleDocument => isLiteral(t))
       .filter((t) => this.isExtensionValid(t));
 
+    const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
+    const RDFS_COMMENT = 'http://www.w3.org/2000/01/rdf-schema#comment';
+
     for (const t of literalTriples) {
       log.silly('Extending path with LiteralTriple', t);
       const prop = t.predicate;
@@ -380,6 +383,11 @@ export class TraversalPathClass extends PathClass {
         ep.predicates.elems = Array.from(new Set([...this.predicates.elems, prop]));
         log.silly('New path with literal head', ep);
         extendedPaths[prop][literalKey] = ep;
+
+        // Only add rdfs:label and rdfs:comment to procTriples
+        if (prop === RDFS_LABEL || prop === RDFS_COMMENT) {
+          procTriples.push({ id: t._id.toString(), type: TripleType.LITERAL });
+        }
       }
     }
 

--- a/models/src/Process/process-crawl-rate.test.ts
+++ b/models/src/Process/process-crawl-rate.test.ts
@@ -1,10 +1,10 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getCrawlRate } from './process-data';
-import { Resource } from '../Resource';
+import { ProcessDoneResource } from '../ProcessDoneResource';
 
-vi.mock('../Resource', () => ({
-  Resource: {
+vi.mock('../ProcessDoneResource', () => ({
+  ProcessDoneResource: {
     countDocuments: vi.fn()
   }
 }));
@@ -22,7 +22,7 @@ describe('getCrawlRate', () => {
   });
 
   it('should return crawl rate in resources per minute', async () => {
-    vi.mocked(Resource.countDocuments).mockResolvedValue(60);
+    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(60);
 
     const result = await getCrawlRate(mockProcess as any, 5);
 
@@ -30,7 +30,7 @@ describe('getCrawlRate', () => {
   });
 
   it('should return 0 when no resources exist', async () => {
-    vi.mocked(Resource.countDocuments).mockResolvedValue(0);
+    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(0);
 
     const result = await getCrawlRate(mockProcess as any, 5);
 
@@ -38,7 +38,7 @@ describe('getCrawlRate', () => {
   });
 
   it('should use default window of 5 minutes', async () => {
-    vi.mocked(Resource.countDocuments).mockResolvedValue(30);
+    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(30);
 
     const result = await getCrawlRate(mockProcess as any);
 
@@ -46,11 +46,11 @@ describe('getCrawlRate', () => {
   });
 
   it('should calculate rate based on process ID', async () => {
-    vi.mocked(Resource.countDocuments).mockResolvedValue(10);
+    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(10);
 
     await getCrawlRate(mockProcess as any, 5);
 
-    expect(Resource.countDocuments).toHaveBeenCalledWith(
+    expect(ProcessDoneResource.countDocuments).toHaveBeenCalledWith(
       expect.objectContaining({
         processId: 'test-pid-123'
       })

--- a/models/src/Process/process-data.ts
+++ b/models/src/Process/process-data.ts
@@ -555,13 +555,11 @@ export function curPredsBranchFactor(
 }
 
 export interface PathProgress {
-  done: number;
   remaining: {
     unvisited: number;
     crawling: number;
     checking: number;
   };
-  total: number;
 }
 
 export async function getPathProgress(process: ProcessClass): Promise<PathProgress> {
@@ -577,30 +575,12 @@ export async function getPathProgress(process: ProcessClass): Promise<PathProgre
     remainingUnvisited = await EndpointPath.countDocuments(stepQuery as any);
   }
 
-  // Count done paths (all done paths for this process)
-  const doneQuery = {
-    processId: process.pid,
-    status: 'active',
-    'head.type': HEAD_TYPE.URL,
-    'head.domain.isUnvisited': false,
-    'head.status': 'done'
-  };
-
-  let done: number;
-  if (pathType === PathType.TRAVERSAL) {
-    done = await TraversalPath.countDocuments(doneQuery as any);
-  } else {
-    done = await EndpointPath.countDocuments(doneQuery as any);
-  }
-
   return {
-    done,
     remaining: {
       unvisited: remainingUnvisited,
       crawling: 0,
       checking: 0
-    },
-    total: done + remainingUnvisited
+    }
   };
 }
 

--- a/models/src/Process/process-data.ts
+++ b/models/src/Process/process-data.ts
@@ -2,7 +2,8 @@ import { ProcessClass } from './Process';
 import { BranchFactorClass } from './aux-classes';
 import { ProcessTriple } from '../ProcessTriple';
 import { Resource } from '../Resource';
-import { TraversalPath, EndpointPath } from '../Path';
+import { ProcessDoneResource } from '../ProcessDoneResource';
+import { TraversalPath, EndpointPath, HEAD_TYPE } from '../Path';
 import {
   LiteralTriple,
   LiteralTripleClass,
@@ -18,6 +19,7 @@ import { PathType, type SimpleTriple, TripleType } from '@derzis/common';
 import { ResourceLabel } from '../ResourceLabel';
 import { createLogger } from '@derzis/common/server';
 import { Types } from 'mongoose';
+import { buildStepPathQuery } from './process-paths';
 
 const log = createLogger('process-data');
 
@@ -556,37 +558,41 @@ export interface PathProgress {
 
 export async function getPathProgress(process: ProcessClass): Promise<PathProgress> {
   const pathType = process.curPathType;
-  const seeds = process.currentStep.seeds;
 
-  const baseQuery = {
-    'seed.url': { $in: seeds }
-  };
-
-  const pipeline = [{ $match: baseQuery }, { $group: { _id: '$head.status', count: { $sum: 1 } } }];
-
-  const PathModel = pathType === PathType.TRAVERSAL ? TraversalPath : EndpointPath;
-  const aggregateResult = PathModel.aggregate<{ _id: string | null; count: number }>(pipeline);
-
-  const counts: Record<string, number> = {};
-  for await (const r of aggregateResult) {
-    if (r._id) {
-      counts[r._id] = r.count;
-    }
+  // Count unvisited paths matching the current step constraints (same as "Matching paths")
+  let remainingUnvisited: number;
+  if (pathType === PathType.TRAVERSAL) {
+    const stepQuery = buildStepPathQuery(process, pathType);
+    remainingUnvisited = await TraversalPath.countDocuments(stepQuery as any);
+  } else {
+    const stepQuery = buildStepPathQuery(process, pathType);
+    remainingUnvisited = await EndpointPath.countDocuments(stepQuery as any);
   }
 
-  const done = counts['done'] || 0;
-  const crawling = counts['crawling'] || 0;
-  const checking = counts['checking'] || 0;
-  const unvisited = counts['unvisited'] || 0;
+  // Count done paths (all done paths for this process)
+  const doneQuery = {
+    processId: process.pid,
+    status: 'active',
+    'head.type': HEAD_TYPE.URL,
+    'head.domain.isUnvisited': false,
+    'head.status': 'done'
+  };
+
+  let done: number;
+  if (pathType === PathType.TRAVERSAL) {
+    done = await TraversalPath.countDocuments(doneQuery as any);
+  } else {
+    done = await EndpointPath.countDocuments(doneQuery as any);
+  }
 
   return {
     done,
     remaining: {
-      unvisited,
-      crawling,
-      checking
+      unvisited: remainingUnvisited,
+      crawling: 0,
+      checking: 0
     },
-    total: done + crawling + checking + unvisited
+    total: done + remainingUnvisited
   };
 }
 
@@ -596,10 +602,9 @@ export async function getCrawlRate(
 ): Promise<number> {
   const cutoffTime = new Date(Date.now() - windowMinutes * 60 * 1000);
 
-  const count = await Resource.countDocuments({
+  const count = await ProcessDoneResource.countDocuments({
     processId: process.pid,
-    status: 'done',
-    updatedAt: { $gte: cutoffTime }
+    createdAt: { $gte: cutoffTime }
   });
 
   return count / windowMinutes;

--- a/models/src/Process/process-data.ts
+++ b/models/src/Process/process-data.ts
@@ -40,8 +40,16 @@ export async function getLabelDataForProcess(pid: string) {
     return [];
   }
 
+  return getLabelDataForUrls(labels.map((l) => l.url));
+}
+
+export async function getLabelDataForUrls(urls: string[]) {
+  if (!urls.length) {
+    return [];
+  }
+
   const triples: LiteralTripleDocument[] = await LiteralTriple.find({
-    subject: { $in: labels.map((l) => l.url) },
+    subject: { $in: urls },
     predicate: {
       $in: [RDFS_LABEL, RDFS_COMMENT]
     }
@@ -56,7 +64,7 @@ export async function getLabelDataForProcess(pid: string) {
   }
 
   const res: { url: string; triples: LiteralTripleDocument[] }[] = [];
-  for (const url of labels.map((l) => l.url)) {
+  for (const url of urls) {
     if (triplesBySubj[url]) {
       res.push({
         url,
@@ -608,4 +616,15 @@ export async function getCrawlRate(
   });
 
   return count / windowMinutes;
+}
+
+export async function getDistinctPathHeadsRemaining(process: ProcessClass): Promise<number> {
+  const pathType = process.curPathType;
+  const stepQuery = buildStepPathQuery(process, pathType);
+
+  if (pathType === PathType.TRAVERSAL) {
+    return await TraversalPath.distinct('head.url', stepQuery as any).then((arr) => arr.length);
+  } else {
+    return await EndpointPath.distinct('head.url', stepQuery as any).then((arr) => arr.length);
+  }
 }

--- a/models/src/Process/process-notifications.ts
+++ b/models/src/Process/process-notifications.ts
@@ -3,8 +3,9 @@ import { createLogger } from '@derzis/common/server';
 import { sendEmail } from '@derzis/common/server';
 import { webhookPost } from '@derzis/common/server';
 import { type LiteralTripleDocument } from '../Triple';
-import { getLabelDataForProcess } from './process-data';
+import { getLabelDataForProcess, getLabelDataForUrls } from './process-data';
 import { type ProcessMetrics } from './process-metrics';
+import type { SimpleTriple } from '@derzis/common';
 const log = createLogger('ProcessNotifications');
 
 export async function notifyLabelsFetched(pid: string) {
@@ -33,6 +34,39 @@ export async function notifyLabelsFetched(pid: string) {
   const notif: ProcessNotification = { ok: true, data };
 
   log.info(`Sending labels to Cardea for process ${pid}`, process.notification.webhook ?? '');
+
+  if (process.notification.webhook) {
+    await notifyWebhook(process.notification.webhook, notif);
+  }
+}
+
+export async function notifySingleLabelFetched(url: string, triples: SimpleTriple[], pid: string) {
+  if (!triples.length) {
+    log.debug(`No triples for label ${url}, skipping notification`);
+    return;
+  }
+
+  const process = await Process.findOne({ pid });
+  if (!process) {
+    log.error(`Process ${pid} not found when sending single label to Cardea`);
+    return;
+  }
+
+  const labelData = [{ url, triples }];
+
+  const data: LabelFetchedNotification = {
+    pid,
+    messageType: 'OK_LABEL_FETCHED',
+    message: `Process ${pid} has fetched label for ${url} (${triples.length} triples).`,
+    details: { labels: labelData }
+  };
+
+  const notif: ProcessNotification = { ok: true, data };
+
+  log.info(
+    `Sending single label to Cardea for process ${pid}: ${url}`,
+    process.notification.webhook ?? ''
+  );
 
   if (process.notification.webhook) {
     await notifyWebhook(process.notification.webhook, notif);
@@ -255,6 +289,16 @@ export type LabelsFetchedNotification = BaseProcNotification & {
   messageType: 'OK_LABELS_FETCHED';
 };
 
+export type LabelFetchedNotification = BaseProcNotification & {
+  details: {
+    labels: Array<{
+      url: string;
+      triples: SimpleTriple[];
+    }>;
+  };
+  messageType: 'OK_LABEL_FETCHED';
+};
+
 export type MetricsCalculatedNotification = BaseProcNotification & {
   details: {
     stepIndex: number;
@@ -271,5 +315,6 @@ type ProcessNotification = {
     | ProcStartNotification
     | ProcCreatedNotification
     | LabelsFetchedNotification
+    | LabelFetchedNotification
     | MetricsCalculatedNotification;
 };

--- a/models/src/Process/process-progress.test.ts
+++ b/models/src/Process/process-progress.test.ts
@@ -4,6 +4,7 @@ import { getPathProgress } from './process-data';
 import { TraversalPath } from '../Path/TraversalPath';
 import { EndpointPath } from '../Path/EndpointPath';
 import type { ProcessClass } from './Process';
+import { PathType } from '@derzis/common';
 
 // Mock config
 vi.mock('@derzis/config', () => ({
@@ -19,37 +20,17 @@ vi.mock('@derzis/config', () => ({
   }
 }));
 
-vi.mock('../Path/TraversalPath', () => {
-  const mockAggregate = vi.fn().mockImplementation(() => {
-    return {
-      [Symbol.asyncIterator]: async function* () {
-        yield { _id: 'done', count: 0 };
-      }
-    };
-  });
-  return {
-    TraversalPath: {
-      aggregate: mockAggregate,
-      countDocuments: vi.fn()
-    }
-  };
-});
+vi.mock('../Path/TraversalPath', () => ({
+  TraversalPath: {
+    countDocuments: vi.fn()
+  }
+}));
 
-vi.mock('../Path/EndpointPath', () => {
-  const mockAggregate = vi.fn().mockImplementation(() => {
-    return {
-      [Symbol.asyncIterator]: async function* () {
-        yield { _id: 'done', count: 0 };
-      }
-    };
-  });
-  return {
-    EndpointPath: {
-      aggregate: mockAggregate,
-      countDocuments: vi.fn()
-    }
-  };
-});
+vi.mock('../Path/EndpointPath', () => ({
+  EndpointPath: {
+    countDocuments: vi.fn()
+  }
+}));
 
 describe('getPathProgress', () => {
   const mockProcess = {
@@ -63,61 +44,80 @@ describe('getPathProgress', () => {
     vi.clearAllMocks();
   });
 
-  const createMockAggregate = (results: { _id: string; count: number }[]) => {
-    return {
-      [Symbol.asyncIterator]: async function* () {
-        for (const r of results) {
-          yield r;
-        }
-      }
-    };
-  };
-
-  it('should return correct counts when TraversalPath is used', async () => {
-    // This test is skipped because mocking aggregate is complex
-    // The function is tested indirectly via integration tests
-    expect(true).toBe(true);
-  });
-
-  it('should return correct counts for different path statuses', async () => {
-    expect(true).toBe(true);
-  });
-
-  it('should return zero counts when no paths exist', async () => {
-    const TP = TraversalPath;
-    const originalAggregate = TP.aggregate;
-    TP.aggregate = vi.fn().mockImplementation(() => createMockAggregate([]));
+  it('should return zero counts when no paths exist for traversal', async () => {
+    mockProcess.curPathType = PathType.TRAVERSAL;
+    TraversalPath.countDocuments = vi.fn().mockResolvedValue(0);
+    // Also mock EndpointPath in case
+    EndpointPath.countDocuments = vi.fn().mockResolvedValue(0);
 
     const result = await getPathProgress(mockProcess);
 
-    TP.aggregate = originalAggregate;
-
     expect(result.done).toBe(0);
+    expect(result.remaining.unvisited).toBe(0);
     expect(result.remaining.crawling).toBe(0);
     expect(result.remaining.checking).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('should return zero counts when no paths exist for endpoint', async () => {
+    mockProcess.curPathType = PathType.ENDPOINT;
+    EndpointPath.countDocuments = vi.fn().mockResolvedValue(0);
+    TraversalPath.countDocuments = vi.fn().mockResolvedValue(0);
+
+    const result = await getPathProgress(mockProcess);
+
+    expect(result.done).toBe(0);
     expect(result.remaining.unvisited).toBe(0);
     expect(result.total).toBe(0);
   });
 
-  it('should filter by process ID', async () => {
-    const TP = TraversalPath;
-    const originalAggregate = TP.aggregate;
-    TP.aggregate = vi.fn().mockImplementation(() => createMockAggregate([]));
-
-    await getPathProgress(mockProcess);
-
-    // Just verify it runs without error
-    TP.aggregate = originalAggregate;
-  });
-
-  it('should return object with correct structure', async () => {
-    const TP = TraversalPath;
-    const originalAggregate = TP.aggregate;
-    TP.aggregate = vi.fn().mockImplementation(() => createMockAggregate([]));
+  it('should return correct counts when paths exist for endpoint', async () => {
+    mockProcess.curPathType = PathType.ENDPOINT;
+    const remainingCount = 3;
+    const doneCount = 8;
+    EndpointPath.countDocuments = vi.fn().mockImplementation(async (query: any) => {
+      if (query['head.status'] === 'unvisited') {
+        return remainingCount;
+      }
+      if (query['head.status'] === 'done') {
+        return doneCount;
+      }
+      return 0;
+    });
+    TraversalPath.countDocuments = vi.fn().mockResolvedValue(0); // not used
 
     const result = await getPathProgress(mockProcess);
 
-    TP.aggregate = originalAggregate;
+    expect(result.done).toBe(doneCount);
+    expect(result.remaining.unvisited).toBe(remainingCount);
+    expect(result.total).toBe(doneCount + remainingCount);
+  });
+
+  it('should use process ID and correct filters', async () => {
+    mockProcess.curPathType = PathType.TRAVERSAL;
+    const mockCount = vi.fn().mockResolvedValue(0);
+    TraversalPath.countDocuments = mockCount;
+
+    await getPathProgress(mockProcess);
+
+    // We expect two calls: one for done, one for remaining
+    expect(mockCount).toHaveBeenCalledTimes(2);
+    // Both calls should include processId
+    expect(mockCount).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ processId: 'test-pid-123' })
+    );
+    expect(mockCount).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ processId: 'test-pid-123' })
+    );
+  });
+
+  it('should return object with correct structure', async () => {
+    mockProcess.curPathType = PathType.TRAVERSAL;
+    TraversalPath.countDocuments = vi.fn().mockResolvedValue(0);
+
+    const result = await getPathProgress(mockProcess);
 
     expect(result).toHaveProperty('done');
     expect(result).toHaveProperty('remaining');

--- a/models/src/Process/process-progress.test.ts
+++ b/models/src/Process/process-progress.test.ts
@@ -52,11 +52,9 @@ describe('getPathProgress', () => {
 
     const result = await getPathProgress(mockProcess);
 
-    expect(result.done).toBe(0);
     expect(result.remaining.unvisited).toBe(0);
     expect(result.remaining.crawling).toBe(0);
     expect(result.remaining.checking).toBe(0);
-    expect(result.total).toBe(0);
   });
 
   it('should return zero counts when no paths exist for endpoint', async () => {
@@ -66,21 +64,15 @@ describe('getPathProgress', () => {
 
     const result = await getPathProgress(mockProcess);
 
-    expect(result.done).toBe(0);
     expect(result.remaining.unvisited).toBe(0);
-    expect(result.total).toBe(0);
   });
 
   it('should return correct counts when paths exist for endpoint', async () => {
     mockProcess.curPathType = PathType.ENDPOINT;
     const remainingCount = 3;
-    const doneCount = 8;
     EndpointPath.countDocuments = vi.fn().mockImplementation(async (query: any) => {
       if (query['head.status'] === 'unvisited') {
         return remainingCount;
-      }
-      if (query['head.status'] === 'done') {
-        return doneCount;
       }
       return 0;
     });
@@ -88,9 +80,7 @@ describe('getPathProgress', () => {
 
     const result = await getPathProgress(mockProcess);
 
-    expect(result.done).toBe(doneCount);
     expect(result.remaining.unvisited).toBe(remainingCount);
-    expect(result.total).toBe(doneCount + remainingCount);
   });
 
   it('should use process ID and correct filters', async () => {
@@ -100,15 +90,9 @@ describe('getPathProgress', () => {
 
     await getPathProgress(mockProcess);
 
-    // We expect two calls: one for done, one for remaining
-    expect(mockCount).toHaveBeenCalledTimes(2);
-    // Both calls should include processId
+    expect(mockCount).toHaveBeenCalledTimes(1);
     expect(mockCount).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ processId: 'test-pid-123' })
-    );
-    expect(mockCount).toHaveBeenNthCalledWith(
-      2,
       expect.objectContaining({ processId: 'test-pid-123' })
     );
   });
@@ -119,9 +103,7 @@ describe('getPathProgress', () => {
 
     const result = await getPathProgress(mockProcess);
 
-    expect(result).toHaveProperty('done');
     expect(result).toHaveProperty('remaining');
-    expect(result).toHaveProperty('total');
     expect(result.remaining).toHaveProperty('unvisited');
     expect(result.remaining).toHaveProperty('crawling');
     expect(result.remaining).toHaveProperty('checking');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,120 @@
       "license": "ISC",
       "devDependencies": {
         "husky": "9.1.7",
-        "lint-staged": "16.4.0"
+        "lint-staged": "16.4.0",
+        "prettier": "3.8.1",
+        "prettier-plugin-svelte": "3.5.1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -55,6 +168,28 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -88,6 +223,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -104,6 +250,14 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/devalue": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.0.tgz",
+      "integrity": "sha512-qCvc8m7cImp1QDCsiY+C2EdSBWSj7Ucfoq87scSdYboDiIKdvMtFbH1U2VReBls6WMhMaUOoK3ZJEDNG/7zm3w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
@@ -123,6 +277,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/esrap": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
+      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@typescript-eslint/types": "^8.2.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -177,6 +351,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -219,6 +404,14 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -254,6 +447,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mimic-function": {
@@ -296,6 +500,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
+      "integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/restore-cursor": {
@@ -395,6 +626,35 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/svelte": {
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.2.tgz",
+      "integrity": "sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.6.4",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.4",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -456,6 +716,14 @@
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
       }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "devDependencies": {
     "husky": "9.1.7",
-    "lint-staged": "16.4.0"
+    "lint-staged": "16.4.0",
+    "prettier": "3.8.1",
+    "prettier-plugin-svelte": "3.5.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
## Summary
- Send Cardea webhook notifications per label when extend=false, returning existing done labels on POST
- Refine process progress metrics to count step-matching paths and expose distinct head counts in SSE UI
- Adjust label handling to prefer English labels with tagless fallback, and limit procTriples to rdfs:label/comment
- Update tests to match revised path progress and crawl rate counting
- Add Prettier tooling (prettier + prettier-plugin-svelte) at the repo root

## Files Changed
- manager/src/lib/Manager.ts: notify per label and adjust label triple selection/processing
- manager/src/routes/api/processes/[pid]/events/+server.ts: refresh process, include distinct heads in progress events
- manager/src/routes/api/processes/[pid]/labels/+server.ts: return existing done labels on creation
- manager/src/routes/processes/[pid]/+page.svelte: display distinct heads and updated progress UI
- models/src/Process/process-data.ts: step-based progress counts, crawl rate via done resources, distinct head count helper
- models/src/Process/process-notifications.ts: add OK_LABEL_FETCHED notification
- models/src/Path/EndpointPath.ts: limit procTriples to label/comment literals
- models/src/Path/TraversalPath.ts: limit procTriples to label/comment literals
- models/src/Process/process-crawl-rate.test.ts: update mock target for crawl rate
- models/src/Process/process-progress.test.ts: adjust for new progress calculation
- package.json: add Prettier dependencies
- package-lock.json: lockfile updates for Prettier tooling

## Impact (Balanced)
- **New**: Per-label webhook notifications and immediate label data returned when posting labels
- **Modified**: Progress calculations now reflect step-matching path counts and distinct head counts; UI text updated
- **Modified**: Label triple selection prefers English but falls back to tagless; non-label literal triples no longer added to procTriples
- **Tooling**: Prettier and Svelte Prettier plugin added at the root

## Notes
- No migration steps identified; consumers of progress events should expect `distinctHeads` and no `done` count
- Webhook consumers should handle OK_LABEL_FETCHED payloads