### PR TITLE
feat: replace predicate branch factor with explicit direction and harden crawl pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,314 @@
-# derzis
+# Derzis
 
+**Derzis** is an open-source, path-aware Linked Data crawler. Given a set of seed
+resources (RDF IRIs), it traverses the Linked Data cloud by recursively
+dereferencing the IRIs returned in RDF documents, following the semantic links
+(extracted triples) found along the way.
 
-## Dependencies
+Unlike generic Semantic Web crawlers, Derzis records the _paths_ it follows while
+crawling. This makes it possible to constrain the crawling frontier using
+**property-path restrictions** — limiting how many distinct properties a path may
+contain, how deep it may go, which predicates to follow, and in which direction —
+so that a potentially enormous graph is reduced to a manageable, relevant
+sub-graph centred on the seed resources.
 
+- Source: <https://github.com/andrefs/derzis>
+- Paper: _Derzis: a path aware linked data crawler_, SLATE 2021 (OASIcs Vol. 94,
+  Article 1). The codebase has since evolved well beyond the paper; this README
+  describes the current implementation, which is the source of truth.
 
-## Running locally
+---
 
-### Manager
+## Why a path-aware crawler?
 
-You can run the Manager locally by running
+Accessing the Semantic Web can be done in several ways: downloading large tripleset
+dumps, querying SPARQL/Triple Pattern Fragments endpoints, custom RDF APIs, or
+**dereferencing resource IRIs** (the _follow-your-nose_ / Linked Data interface).
+The Linked Data interface is light for both clients and servers — no complex query
+engine is needed and data is always up to date — but it does not support complex
+queries on its own. Recursively following links is enough to gather information
+about a set of resources, or to extract the relevant sub-graph that can then be
+processed with other methods.
+
+Derzis targets exactly this: it starts from seed IRIs and crawls outward, but keeps
+track of each path so the traversal can be constrained. This is particularly useful
+as a pre-processing step for graph-based semantic measures, which are often
+impractical on full-scale knowledge graphs.
+
+### Graph-reduction strategies
+
+During a crawl, Derzis reduces the explored graph using the following rules:
+
+- **Triples where the crawled resource is the _predicate_ are discarded.** Such
+  triples describe the property itself (e.g. `ex:hasColor rdf:type rdf:Property`),
+  not the resource being crawled.
+- **Crawling follows only subject/object resources**, never predicate IRIs.
+- **A path may contain at most a maximum number of distinct properties**
+  (`maxPathProps`). Homogeneous paths tend to represent meaningful chains of
+  connections rather than noise.
+- **A maximum crawl depth** (`maxPathLength`) can be defined; resources too far
+  from the seeds are usually less relevant.
+- **Predicate limitations** (whitelist/blacklist) and **directionality** further
+  focus the crawl (see [Crawl configuration](#crawl-configuration)).
+
+---
+
+## Architecture
+
+Derzis is a distributed, manager/worker system. All components are written in
+TypeScript/Node.js and communicate over a Redis message bus, with MongoDB as the
+persistent store.
+
+```
+                ┌────────────┐      Redis pub/sub       ┌────────────┐
+                │  Manager   │ ───────────────────────► │  Worker(s) │
+                │ (SvelteKit)│ ◄─────────────────────── │ (Node.js)  │
+                └─────┬──────┘                          └─────┬──────┘
+                      │                                        │
+                      ▼                                        ▼
+                 ┌─────────┐                              HTTP (Linked Data)
+                 │ MongoDB │                              + robots.txt checks
+                 └─────────┘
+```
+
+| Component     | Package            | Role                                                                                                                                                              |
+| ------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Manager**   | `derzis-manager`   | SvelteKit web UI + REST API. Decides what to crawl next, distributes jobs to workers, persists data, exposes live progress over Server-Sent Events.               |
+| **Worker**    | `derzis-worker`    | Standalone Node.js service. Fetches `robots.txt`, dereferences resource IRIs (with content negotiation), parses RDF, and reports results back over Redis.         |
+| **Validator** | `derzis-validator` | CLI / Express tool for validation and comparison of crawled data (e.g. diffing exports, viewing graphs).                                                          |
+| **Models**    | `@derzis/models`   | MongoDB data models (TypeGoose): `Domain`, `Resource`, `Triple`, `Process`, `Path` (with `TraversalPath` / `EndpointPath` discriminators), `ProcessDoneResource`. |
+| **Common**    | `@derzis/common`   | Shared utilities, types, and logging (`createLogger`).                                                                                                            |
+| **Config**    | `@derzis/config`   | Configuration loader (environment variables + dotenv).                                                                                                            |
+
+The Manager, each Worker, the database and Redis can all run on separate machines,
+making the crawler horizontally scalable.
+
+### Path model: traversal vs. endpoint
+
+Derzis tracks two kinds of paths (both stored as `Path` discriminator documents):
+
+- **`TraversalPath`** — the default. A path rooted at a seed, extended by following
+  triples whose subject/object becomes the new path _head_ (a URL resource).
+- **`EndpointPath`** — used when a crawl step is configured to
+  `convertToEndpointPaths`. Active traversal paths are converted into endpoint
+  paths that additionally record the **shortest path length** to reach each head and
+  the set of **`seedPaths`** (per-seed distances). An endpoint path head may be a
+  URL _or a literal_ value, capturing the terminal nodes of a property path.
+
+---
+
+## How a crawl works
+
+A crawl is organised as a **Process** made of ordered **Steps**. Each step takes the
+current set of seed resources (plus any newly discovered seeds) and expands the
+active paths according to the step's configuration.
+
+1. For every active path, its current _head_ resource is queued for dereferencing.
+   The Manager claims the domain (so only one worker touches it at a time) and
+   respects `robots.txt` rules and the `Crawl-Delay` directive.
+2. The Worker dereferences the resource (HTTP `GET` with RDF `Accept` headers,
+   falling back to `Link`/`<link>` metadata when the server does not honour content
+   negotiation), parses the RDF, and returns the triples.
+3. Each triple is used to **extend** the path: if the path restrictions are still
+   satisfied (length, distinct properties, predicate limitations, directionality),
+   a new path is created with the triple's subject or object as the new head.
+4. Paths that violate restrictions, or whose head has already been fully visited,
+   are marked finished.
+5. When no active paths remain, the step completes; a new step may be added to
+   continue crawling (possibly with different restrictions or converting to endpoint
+   paths).
+
+The restricted graph can then be exported as RDF (see [Exports](#exports)).
+
+---
+
+## Crawl configuration
+
+Each step (`StepClass`) supports the following parameters:
+
+| Parameter                | Default | Description                                                                                                                                                               |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `seeds`                  | —       | Seed resource IRIs to start/continue crawling from.                                                                                                                       |
+| `maxPathLength`          | `2`     | Maximum number of nodes (depth) in a path.                                                                                                                                |
+| `maxPathProps`           | `1`     | Maximum number of **distinct** properties allowed in a path.                                                                                                              |
+| `predLimit`              | —       | _(Deprecated)_ Simple whitelist/blacklist of predicates. Use `predLimitations`.                                                                                           |
+| `predLimitations`        | `[]`    | Per-predicate limitations with `past`/`future` constraints (whitelist/blacklist).                                                                                         |
+| `followDirection`        | `false` | Whether to enforce predicate directionality when extending paths.                                                                                                         |
+| `predsDirection`         | `[]`    | Per-predicate direction metadata (`subject` \| `object` \| `none`, plus a `ratio`). Required for `followDirection` to be meaningful; if missing, all triples are allowed. |
+| `resetErrors`            | `false` | Reset `error` statuses of resources, domains and paths at the start of the step.                                                                                          |
+| `convertToEndpointPaths` | `false` | After this step's expansion, convert active `TraversalPath`s into `EndpointPath`s.                                                                                        |
+
+Predicate **directionality** is computed from branch-factor statistics (how often a
+predicate points subject→object vs object→subject) and stored explicitly per step as
+`predsDirection`. When `followDirection` is enabled, only triples matching the
+expected direction are followed.
+
+---
+
+## Repository layout
+
+This is a TypeScript monorepo (npm workspaces / project references):
+
+```
+derzis-dev/
+├── common/      @derzis/common      shared utilities & logging
+├── config/      @derzis/config      configuration loader
+├── models/      @derzis/models      MongoDB models & aggregation logic
+├── manager/     derzis-manager      SvelteKit UI + REST API
+├── worker/      derzis-worker       background crawl worker
+├── validator/   derzis-validator    validation & comparison CLI
+├── docker-compose.yml               full-stack local deployment
+└── AGENTS.md                     guidance for AI agents working on the code
+```
+
+---
+
+## Getting started
+
+### Prerequisites
+
+- Node.js (see individual package `engines`/`package.json`)
+- A running **MongoDB** and **Redis** instance (or use Docker Compose)
+- npm
+
+### Option A — Docker Compose (recommended for the full stack)
+
+Copy the environment file and start everything:
+
+```bash
+cp .env.example .env
+docker compose up --build --watch --remove-orphans
+```
+
+This starts:
+
+| Service   | Port (configurable) | Notes                    |
+| --------- | ------------------- | ------------------------ |
+| MongoDB   | `60001`             | persisted to `./data/db` |
+| Redis     | `60002`             | pub/sub bus              |
+| Manager   | `60003`             | web UI + API             |
+| Worker    | —                   | background service       |
+| Validator | `60004`             | validation/comparison UI |
+
+The manager dev server can also be run directly with `npm run dev` (default SvelteKit
+port `5173`, preview `4173`).
+
+### Option B — Local development
+
+Assuming MongoDB, Redis (and optionally a Fuseki/SPARQL endpoint) are already running:
+
+```bash
+# Terminal 1 — Manager
+cd manager && npm install && npm run dev
+
+# Terminal 2 — Worker
+cd worker && npm install && npm run dev
+```
+
+The Manager log file is `manager/logs/current`; the Worker log is `worker/logs/current`.
+
+### Environment
+
+Configuration is loaded from environment variables via `@derzis/config`. Copy
+`.env.example` to `.env` and adjust ports, hosts, database names and the crawl delay
+(`config.http.crawlDelay`). Secrets (MongoDB URI, Redis URL, API tokens) must come
+from the environment — never commit them.
+
+### Resetting the database
 
 ```bash
 cd manager
-npm run dev
+npm run db:drop:dev     # drop development database
+npm run db:drop:test    # drop test database
+npm run db:setup:test   # seed test data
 ```
 
-You can also use Docker:
+---
+
+## Usage
+
+### Web UI
+
+Open the Manager in a browser (e.g. <http://localhost:60003> or
+<http://localhost:5173> in dev). From there you can:
+
+- create a crawl **Process** with seed resources and step parameters;
+- watch live progress (Server-Sent Events) including per-step `extending` /
+  `crawling` progress, crawl rate and ETA;
+- inspect domains, resources, paths and triples;
+- view computed metrics (branch factors, seed predicates, global statistics);
+- export the crawled graph.
+
+### REST API
+
+The Manager exposes a REST API under `/api/processes`:
+
+| Endpoint                                                                    | Purpose                                  |
+| --------------------------------------------------------------------------- | ---------------------------------------- |
+| `GET  /api/processes`                                                       | list processes                           |
+| `POST /api/processes`                                                       | create a process with seeds + first step |
+| `GET  /api/processes/[pid]`                                                 | process details                          |
+| `POST /api/processes/[pid]/add-step`                                        | append a crawl step                      |
+| `GET  /api/processes/[pid]/events`                                          | SSE live progress stream                 |
+| `GET  /api/processes/[pid]/metrics`                                         | crawl metrics                            |
+| `GET  /api/processes/[pid]/stats`                                           | statistics                               |
+| `GET  /api/processes/[pid]/calc-metrics/{branch-factors,global,seed-preds}` | compute metric batches                   |
+| `GET  /api/processes/[pid]/triples.nt.gz`                                   | export as gzipped N-Triples              |
+| `GET  /api/processes/[pid]/triples.json.gz`                                 | export as gzipped JSON                   |
+| `GET  /api/processes/[pid]-full.zip`                                        | full export bundle                       |
+
+> **API note:** `add-step` now expects `predsDirection` (an array of
+> `{ url, direction, ratio }`). The legacy `predsBranchFactor` field is rejected
+> with HTTP 400.
+
+### Exports
+
+The crawled (restricted) graph can be exported in RDF or JSON form and used with
+other tools, or loaded into the **Validator** for diffing and graph visualisation.
+
+---
+
+## Development
+
+Each package has its own scripts; run them from within the package directory.
+
+| Package     | Notable scripts                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| `common`    | `typecheck`, `lint`, `format`, `test` (Vitest)                                           |
+| `config`    | (library only)                                                                           |
+| `models`    | `typecheck`, `lint`, `format`, `test` (Vitest)                                           |
+| `manager`   | `dev`, `build`, `preview`, `check`, `test:unit`, `test:integration` (Playwright), `db:*` |
+| `worker`    | `dev`, `build`, `preview`, `test`, `typecheck`, `eslint`                                 |
+| `validator` | `typecheck`, `lint`, `format`, `test`                                                    |
+
+Type-check every package:
 
 ```bash
-docker compose up --build --watch --remove-orphans manager
+for p in common models manager worker validator; do (cd $p && npm run typecheck); done
 ```
 
-### Worker
+The repository follows [Conventional Commits](https://www.conventionalcommits.org/).
+See `AGENTS.md` for detailed coding conventions, the index-sync caveats, and the
+monorepo path aliases (`@derzis/models`, `@derzis/common`, `@derzis/config`).
 
-You can run the Worker locally by running
+### Testing
 
-```bash
-cd worker
-npm run dev
-```
+- **Unit tests** (Vitest) live next to the code they test (e.g. `models/*.test.ts`,
+  `manager/src/**/test.ts`).
+- **Integration tests** (Playwright) live in `manager/tests/` and run against the
+  built app on port `4173`.
 
-You can also use Docker:
+---
 
-```bash
-docker compose up --build --remove-orphans manager
-```
+## License
 
-## Clear development databases
+Derzis is released under the ISC license. See `LICENSE.md` for details.
 
-```bash
-cd manager
-npm run db:drop:dev
-```
+## Citation
+
+If you use Derzis in your research, please cite:
+
+> André F. Santos and José P. Leal. _Derzis: a path aware linked data crawler_.
+> In Ricardo Queirós, Mário Pinto, Alberto Simões, Filipe Portela, and Maria João
+> Pereira, editors, 10th Symposium on Languages, Applications and Technologies
+> (SLATE 2021), OASIcs, Vol. 94, Article 1, 2021.

--- a/common/src/lib/index.ts
+++ b/common/src/lib/index.ts
@@ -2,6 +2,7 @@ export * from './errors';
 export * from './mongoose-validators';
 export * from './types';
 export * from './sanitize';
+export * from './url';
 export * from './direction-ok';
 export * from './logger';
 export * from './redis-reconnector';

--- a/manager/package.json
+++ b/manager/package.json
@@ -8,8 +8,8 @@
   "type": "module",
   "scripts": {
     "prepare": "svelte-kit sync",
-    "dev": "NODE_OPTS='--max-old-space-size=55296' vite dev",
-    "serve": "NODE_OPTS='--max-old-space-size=55296' vite dev --host",
+    "dev": "NODE_OPTIONS='--max-old-space-size=55296' vite dev",
+    "serve": "NODE_OPTIONS='--max-old-space-size=55296' vite dev --host",
     "build": "vite build",
     "preview": "vite preview",
     "test": "npm run test:integration && npm run test:unit",

--- a/manager/src/lib/Manager.ts
+++ b/manager/src/lib/Manager.ts
@@ -23,6 +23,7 @@ import {
 import {
   type JobResult,
   type RobotsCheckResult,
+  type RobotsCheckResultError,
   type CrawlResourceResult,
   TripleType,
   type SimpleLiteralTriple
@@ -80,9 +81,19 @@ export default class Manager {
       try {
         await this.saveRobots(jobResult);
       } catch (e) {
-        // TODO handle errors
-        log.error(`Error saving robots (job #${jobResult.jobId}) for ${jobResult.origin}`);
+        log.error(`Error saving robots (job #${jobResult.jobId}) for ${jobResult.origin}`, e);
         log.info(JSON.stringify(jobResult, null, 2));
+        await Domain.updateOne(
+          { origin: jobResult.origin },
+          {
+            $unset: { workerId: '', jobId: '' },
+            $set: {
+              status: 'unvisited',
+              'robots.status': 'error',
+              'crawl.delay': config.http.crawlDelay || 1
+            }
+          }
+        );
       } finally {
         this.jobs.removeFromBeingSaved(jobResult.origin, jobResult.jobType);
         this.jobs.deregisterJob(jobResult.origin, jobResult.jobId);
@@ -455,9 +466,21 @@ export default class Manager {
     let crawlDelay = config.http.crawlDelay || 1;
 
     if (jobResult.status === 'ok') {
-      const robots = robotsParser(jobResult.origin + '/robots.txt', jobResult.details.robotsText);
-      crawlDelay = robots.getCrawlDelay(config.http.userAgent) || crawlDelay;
-      await Domain.saveRobotsOk(jobResult, crawlDelay);
+      try {
+        const robots = robotsParser(jobResult.origin + '/robots.txt', jobResult.details.robotsText);
+        crawlDelay = robots.getCrawlDelay(config.http.userAgent) || crawlDelay;
+        await Domain.saveRobotsOk(jobResult, crawlDelay);
+      } catch (e) {
+        log.error(`Error parsing robots.txt for ${jobResult.origin}`, e);
+        await Domain.saveRobotsError(
+          {
+            ...jobResult,
+            status: 'not_ok',
+            err: { errorType: 'parsing', message: (e as Error).message, name: 'Parsing Error' }
+          } as RobotsCheckResultError,
+          config.http.crawlDelay || 1
+        );
+      }
     } else {
       await Domain.saveRobotsError(jobResult, crawlDelay);
     }

--- a/manager/src/lib/process-helper.ts
+++ b/manager/src/lib/process-helper.ts
@@ -29,6 +29,7 @@ export async function newProcess(p: RecursivePartial<ProcessClass>): Promise<Pro
   const uniqueSeeds = [...uniqueSeedsSet];
 
   p.currentStep!.seeds = uniqueSeeds;
+  p.currentStep!.createdAt = new Date();
 
   const pathHeads: Map<string, number> = new Map();
   for (const s of uniqueSeeds) {
@@ -88,6 +89,7 @@ export async function addStep(
   const newMPP = params.maxPathProps;
 
   const newStep = {
+    createdAt: new Date(),
     seeds: [...allPreviousSeeds, ...newSeeds],
     maxPathLength: newMPL,
     maxPathProps: newMPP,

--- a/manager/src/lib/process-helper.ts
+++ b/manager/src/lib/process-helper.ts
@@ -68,6 +68,7 @@ export async function addStep(
   pid: string,
   params: MakeOptional<StepClass, 'seeds'> & {
     predLimitations?: { predicate: string; lims: PredicateLimitationType[] }[];
+    predsDirection?: { url: string; direction: 'subject' | 'object' | 'none'; ratio: number }[];
   }
 ) {
   const p = await Process.findOne({ pid, status: 'done' });
@@ -93,7 +94,7 @@ export async function addStep(
     predLimit: params.predLimit,
     predLimitations: params.predLimitations,
     followDirection: params.followDirection as boolean,
-    predsBranchFactor: params.predsBranchFactor,
+    predsDirection: params.predsDirection,
     convertToEndpointPaths: params.convertToEndpointPaths ?? false
   };
 

--- a/manager/src/routes/api/processes/[pid]/add-step/+server.ts
+++ b/manager/src/routes/api/processes/[pid]/add-step/+server.ts
@@ -1,5 +1,5 @@
 import { addStep } from '$lib/process-helper';
-import { PredBranchFactor, Process, StepClass, type PredicateLimitationType } from '@derzis/models';
+import { Process, StepClass, type PredicateLimitationType, PredDirection } from '@derzis/models';
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { createLogger } from '@derzis/common/server';
 import type { MakeOptional } from '$lib/utils';
@@ -16,7 +16,7 @@ interface NewStepReqBody {
       lims: PredicateLimitationType[];
     }[];
     followDirection: boolean;
-    predsBranchFactor?: PredBranchFactor[];
+    predsDirection?: PredDirection[];
     resetErrors: boolean;
     convertToEndpointPaths: boolean;
   };
@@ -57,7 +57,17 @@ export const POST: RequestHandler = async ({ request, params }) => {
     return json({ ok: false, err: { message: 'No process ID provided' } }, { status: 400 });
   }
 
-  console.log('XXXXXXXXXXXXXXX add-step server 3', JSON.stringify(resp.data, null, 2));
+  if ('predsBranchFactor' in resp.data) {
+    return json(
+      {
+        ok: false,
+        err: {
+          message: 'predsBranchFactor is no longer supported; send predsDirection instead'
+        }
+      },
+      { status: 400 }
+    );
+  }
 
   const predLimitations = resp.data.predLimitations || [];
 
@@ -75,7 +85,7 @@ export const POST: RequestHandler = async ({ request, params }) => {
     maxPathProps: resp.data.maxPathProps,
     predLimitations: predLimitations,
     followDirection: resp.data.followDirection,
-    predsBranchFactor: resp.data.predsBranchFactor,
+    predsDirection: resp.data.predsDirection,
     resetErrors: resp.data.resetErrors,
     convertToEndpointPaths: resp.data.convertToEndpointPaths
   };

--- a/manager/src/routes/api/processes/[pid]/events/+server.ts
+++ b/manager/src/routes/api/processes/[pid]/events/+server.ts
@@ -9,6 +9,7 @@ import {
 import type { RequestEvent } from './$types';
 
 const PROGRESS_INTERVAL_MS = 10000;
+const MAX_CONSECUTIVE_ERRORS = 5;
 
 export async function GET({ params }: RequestEvent) {
   const process = await Process.findOne({ pid: params.pid });
@@ -21,6 +22,7 @@ export async function GET({ params }: RequestEvent) {
     start(controller) {
       const encoder = new TextEncoder();
       let isActive = true;
+      let errorsSinceLastSuccess = 0;
 
       const sendEvent = async () => {
         if (!isActive) {
@@ -42,15 +44,57 @@ export async function GET({ params }: RequestEvent) {
             return;
           }
 
+          // Fix 3: emit terminal event and close when process is done/error
+          if (latestProcess.status === 'done' || latestProcess.status === 'error') {
+            const event = {
+              type: latestProcess.status === 'done' ? 'PROCESS_DONE' : 'PROCESS_ERROR',
+              status: latestProcess.status,
+              step: latestProcess.steps.length,
+              totalPaths: latestProcess.currentStep?.doneResourceCount ?? 0
+            };
+            const data = `data: ${JSON.stringify(event)}\n\n`;
+            try {
+              controller.enqueue(encoder.encode(data));
+            } catch (_) {}
+            isActive = false;
+            clearInterval(intervalId);
+            try {
+              controller.close();
+            } catch (_) {}
+            return;
+          }
+
           let event;
           if (latestProcess.status === 'extending') {
             const extendingProgress = await getExtendingProgress(latestProcess);
-            event = {
-              type: 'PROGRESS',
-              phase: 'extending',
-              step: latestProcess.steps.length,
-              extending: extendingProgress
-            };
+            // Fix 2: if no done-head paths to extend (common for endpoint),
+            // show crawling-style progress instead of 0/0
+            if (extendingProgress.total === 0) {
+              const pathProgress = await getPathProgress(latestProcess);
+              const crawlRate = await getCrawlRate(latestProcess, 5);
+              const distinctHeads = await getDistinctPathHeadsRemaining(latestProcess);
+              event = {
+                type: 'PROGRESS',
+                phase: 'crawling',
+                step: latestProcess.steps.length,
+                paths: {
+                  remaining:
+                    pathProgress.remaining.unvisited +
+                    pathProgress.remaining.crawling +
+                    pathProgress.remaining.checking,
+                  distinctHeads,
+                  eta: crawlRate > 0 ? distinctHeads / crawlRate : 0
+                },
+                rate: crawlRate
+              };
+            } else {
+              event = {
+                type: 'PROGRESS',
+                phase: 'extending',
+                step: latestProcess.steps.length,
+                extending: extendingProgress
+              };
+            }
           } else {
             const pathProgress = await getPathProgress(latestProcess);
             const crawlRate = await getCrawlRate(latestProcess, 5);
@@ -75,6 +119,7 @@ export async function GET({ params }: RequestEvent) {
           const data = `data: ${JSON.stringify(event)}\n\n`;
           try {
             controller.enqueue(encoder.encode(data));
+            errorsSinceLastSuccess = 0;
           } catch (enqueueErr) {
             if ((enqueueErr as any).code === 'ERR_INVALID_STATE') {
               isActive = false;
@@ -84,9 +129,13 @@ export async function GET({ params }: RequestEvent) {
             throw enqueueErr;
           }
         } catch (err) {
+          // Fix 1: non-fatal error recovery - keep stream alive, retry next tick
           console.error('Error sending progress event:', err);
-          isActive = false;
-          clearInterval(intervalId);
+          errorsSinceLastSuccess++;
+          if (errorsSinceLastSuccess > MAX_CONSECUTIVE_ERRORS) {
+            isActive = false;
+            clearInterval(intervalId);
+          }
         }
       };
 

--- a/manager/src/routes/api/processes/[pid]/triples.nt.gz/+server.ts
+++ b/manager/src/routes/api/processes/[pid]/triples.nt.gz/+server.ts
@@ -2,14 +2,36 @@ import { createLogger } from '@derzis/common/server';
 import { Process } from '@derzis/models';
 import { error } from '@sveltejs/kit';
 import type { RequestEvent } from './$types';
-import { Readable } from 'stream';
-import { Writer } from 'n3';
+import { Readable, Transform } from 'stream';
+import { StreamWriter, DataFactory } from 'n3';
 import { createGzip } from 'zlib';
 import { pipeline } from 'stream/promises';
 import type { SimpleTriple } from '@derzis/common';
+import { TripleType } from '@derzis/common';
 const log = createLogger('api:processes:[pid]:triples');
-import { DataFactory } from 'n3';
-const { literal, namedNode } = DataFactory;
+const { literal, namedNode, quad } = DataFactory;
+
+function simpleTripleToQuad(triple: SimpleTriple) {
+  const s = namedNode(triple.subject);
+  const p = namedNode(triple.predicate);
+
+  if (triple.type === TripleType.NAMED_NODE) {
+    return quad(s, p, namedNode(triple.object));
+  }
+
+  if (triple.type === TripleType.LITERAL) {
+    const { value, language, datatype } = triple.object;
+    if (language) {
+      return quad(s, p, literal(value, language));
+    }
+    if (datatype) {
+      return quad(s, p, literal(value, namedNode(datatype)));
+    }
+    return quad(s, p, literal(value));
+  }
+
+  return null;
+}
 
 export async function GET({ params, setHeaders }: RequestEvent) {
   const p = await Process.findOne({ pid: params.pid });
@@ -22,52 +44,26 @@ export async function GET({ params, setHeaders }: RequestEvent) {
   const iter = p?.getTriples();
   console.log('Iterating triples for process', params.pid);
 
-  const readableStream = Readable.from(iter, { objectMode: true });
+  const sourceStream = Readable.from(iter, { objectMode: true });
 
-  const writer = new Writer({ format: 'N-Triples' });
-
-  const transformStream = new Readable({
-    objectMode: true,
-    read() {}
-  });
-
-  readableStream.on('data', (quad: SimpleTriple) => {
-    // Logging removed to prevent memory pressure during large exports
-    if (quad.type === 'namedNode') {
-      writer.addQuad(namedNode(quad.subject), namedNode(quad.predicate), namedNode(quad.object));
-    } else if (quad.type === 'literal') {
-      const { value, language, datatype } = quad.object;
-      if (language) {
-        writer.addQuad(
-          namedNode(quad.subject),
-          namedNode(quad.predicate),
-          literal(value, language)
-        );
-      } else if (datatype) {
-        writer.addQuad(
-          namedNode(quad.subject),
-          namedNode(quad.predicate),
-          literal(value, namedNode(datatype))
-        );
-      } else {
-        writer.addQuad(namedNode(quad.subject), namedNode(quad.predicate), literal(value));
+  const toQuadTransform = new Transform({
+    writableObjectMode: true,
+    readableObjectMode: true,
+    transform(triple: SimpleTriple, encoding, callback) {
+      try {
+        const q = simpleTripleToQuad(triple);
+        if (q) {
+          callback(null, q);
+        } else {
+          callback();
+        }
+      } catch (err) {
+        callback(err instanceof Error ? err : new Error(String(err)));
       }
-    } else {
-      // Handle other types if necessary
-      log.warn(`Unknown quad type: ${quad}`);
     }
   });
 
-  readableStream.on('end', () => {
-    writer.end((err, result) => {
-      if (err) transformStream.destroy(err);
-      else {
-        transformStream.push(result);
-        transformStream.push(null);
-      }
-    });
-  });
-
+  const streamWriter = new StreamWriter({ format: 'N-Triples' });
   const gzipStream = createGzip();
 
   setHeaders({
@@ -78,12 +74,18 @@ export async function GET({ params, setHeaders }: RequestEvent) {
     new ReadableStream({
       async start(controller) {
         try {
-          await pipeline(transformStream, gzipStream, async function* (source) {
-            for await (const chunk of source) {
-              controller.enqueue(chunk);
+          await pipeline(
+            sourceStream,
+            toQuadTransform,
+            streamWriter,
+            gzipStream,
+            async function* (source) {
+              for await (const chunk of source) {
+                controller.enqueue(chunk);
+              }
+              controller.close();
             }
-            controller.close();
-          });
+          );
         } catch (err) {
           controller.error(err);
         }

--- a/manager/src/routes/processes/[pid]/+page.server.ts
+++ b/manager/src/routes/processes/[pid]/+page.server.ts
@@ -73,7 +73,7 @@ export const actions: { [name: string]: Action } = {
       maxPathProps,
       predLimitations,
       followDirection,
-      predsBranchFactor: undefined,
+      predsDirection: undefined,
       resetErrors,
       convertToEndpointPaths
     };

--- a/manager/src/routes/processes/[pid]/+page.svelte
+++ b/manager/src/routes/processes/[pid]/+page.svelte
@@ -6,6 +6,7 @@
   import { BiDownload, BiNetworkChart, BiCopy } from 'svelte-icons-pack/bi';
   import { HiSolidMagnifyingGlass } from 'svelte-icons-pack/hi';
   import { onMount, onDestroy } from 'svelte';
+  import { formatDateLabel } from '$lib/utils';
 
   let progress: {
     step: number;
@@ -297,6 +298,15 @@
         <h4>Current step (#{data.proc.steps.length})</h4>
         <Table>
           <tbody>
+            {#if data.proc.currentStep.createdAt}
+              <tr>
+                <th scope="row">Created</th>
+                <td
+                  >{formatDateLabel(new Date(data.proc.currentStep.createdAt)).date}
+                  {formatDateLabel(new Date(data.proc.currentStep.createdAt)).time}</td
+                >
+              </tr>
+            {/if}
             <tr
               ><th scope="row">Max path length</th><td>{data.proc.currentStep.maxPathLength}</td
               ></tr
@@ -335,6 +345,15 @@
       <Table>
         <tbody>
           {#each data.proc.steps.slice(0, -1) as step, i}
+            {#if step.createdAt}
+              <tr>
+                <th scope="row">Created</th>
+                <td
+                  >{formatDateLabel(new Date(step.createdAt)).date}
+                  {formatDateLabel(new Date(step.createdAt)).time}</td
+                >
+              </tr>
+            {/if}
             <tr><th scope="row">Max path length</th><td>{step.maxPathLength}</td></tr>
             <tr><th scope="row">Max path props</th><td>{step.maxPathProps}</td></tr>
             <tr>

--- a/manager/src/routes/processes/[pid]/+page.svelte
+++ b/manager/src/routes/processes/[pid]/+page.svelte
@@ -15,6 +15,12 @@
     extending?: { total: number; remaining: number; extended: number; percentage: number };
   } | null = null;
   let error: string | null = null;
+  let doneSummary: {
+    type: 'PROCESS_DONE' | 'PROCESS_ERROR';
+    status: string;
+    step: number;
+    totalPaths: number;
+  } | null = null;
   let eventSource: EventSource | null = null;
 
   $: isRunning = data.proc.status === 'running' || data.proc.status === 'extending';
@@ -37,7 +43,13 @@
 
     eventSource.onmessage = (event) => {
       try {
-        progress = JSON.parse(event.data);
+        const parsed = JSON.parse(event.data);
+        if (parsed.type === 'PROCESS_DONE' || parsed.type === 'PROCESS_ERROR') {
+          doneSummary = parsed;
+          eventSource?.close();
+        } else {
+          progress = parsed;
+        }
       } catch (e) {
         console.error('Failed to parse SSE event:', e);
       }
@@ -135,7 +147,22 @@
   {/if}
 </header>
 
-{#if isRunning && progress}
+{#if doneSummary}
+  <Alert
+    color={doneSummary.status === 'done' ? 'success' : 'danger'}
+    class="mb-4 d-flex align-items-center"
+  >
+    <div>
+      {#if doneSummary.status === 'done'}
+        <strong>Step {doneSummary.step} completed.</strong>
+        Paths processed: {doneSummary.totalPaths.toLocaleString()}
+      {:else}
+        <strong>Step {doneSummary.step} finished with errors.</strong>
+        Paths processed: {doneSummary.totalPaths.toLocaleString()}
+      {/if}
+    </div>
+  </Alert>
+{:else if isRunning && progress}
   <Alert color="info" class="mb-4 d-flex align-items-center">
     <div class="spinner-border spinner-border-sm me-2" role="status">
       <span class="visually-hidden">Updating...</span>

--- a/manager/src/routes/processes/[pid]/draw-seeds/+page.server.ts
+++ b/manager/src/routes/processes/[pid]/draw-seeds/+page.server.ts
@@ -10,28 +10,19 @@ export const load: PageServerLoad = async ({ params }) => {
     });
   }
 
-  if (!p.currentStep?.predsBranchFactor) {
+  if (!p.currentStep?.predsDirection) {
     throw error(400, {
-      message: 'No predsBranchFactor found for current step'
+      message: 'No predsDirection found for current step'
     });
   }
-
-  console.log('XXXXXXXXXXXXX', p.currentStep.predsBranchFactor);
 
   return {
     proc: {
       pid: p.pid,
       currentStep: {
         seeds: p.currentStep.seeds,
-        branchFactors: p.currentStep.predsBranchFactor.reduce((acc, metric) => {
-          if (!metric.branchFactor) {
-            return acc;
-          }
-          if (metric.branchFactor.obj === 0) {
-            acc.set(metric.url, Infinity);
-            return acc;
-          }
-          acc.set(metric.url, metric.branchFactor?.subj / metric.branchFactor?.obj);
+        branchFactors: p.currentStep.predsDirection.reduce((acc, metric) => {
+          acc.set(metric.url, metric.ratio);
           return acc;
         }, new Map<string, number>())
       }

--- a/models/src/Path/EndpointPath.ts
+++ b/models/src/Path/EndpointPath.ts
@@ -75,6 +75,10 @@ export function isEndpointPathSkeleton(path: PathSkeleton): path is EndpointPath
   }
 )
 @index({ 'head.url': 1, status: 1 }, { name: 'idx_endpoint_head_url_status' })
+@index(
+  { processId: 1, status: 1, 'head.type': 1, 'head.domain.origin': 1 },
+  { name: 'idx_endpoint_process_status_head_domain', partialFilterExpression: { type: 'endpoint' } }
+)
 @index({ 'head.status': 1, status: 1 }, { name: 'idx_endpoint_head_status' })
 @index({ type: 1, 'head.domain.origin': 1, status: 1 }, { name: 'idx_endpoint_domain_status' })
 // Optimized index for endpoint path queries with shortestPathLength sort

--- a/models/src/Path/EndpointPath.ts
+++ b/models/src/Path/EndpointPath.ts
@@ -273,7 +273,7 @@ export class EndpointPathClass extends PathClass {
         .filter((t) => this.isExtensionValid(t) && this.isExtensionAllowed(t, process.currentStep));
 
       const followDirection = process.currentStep.followDirection;
-      const predsBF = process.curPredsBranchFactor();
+      const predsDirection = process.curPredsDirection();
 
       for await (const { blankTriple: t, outgoing, blankNodeId } of iterateBlankNodeOutgoings(
         blankNodeTriples
@@ -286,7 +286,7 @@ export class EndpointPathClass extends PathClass {
 
         // For NamedNode outgoing, also check direction and handle candidate
         if (isNamedNode(outgoing)) {
-          if (!outgoing.directionOk(urlHead.url, followDirection, predsBF)) continue;
+          if (!outgoing.directionOk(urlHead.url, followDirection, predsDirection)) continue;
 
           const newHeadUrl: string =
             outgoing.subject === blankNodeId ? outgoing.object : outgoing.subject;
@@ -386,7 +386,7 @@ function collectNamedNodeCandidates(
 ): Candidate[] {
   const candidates: Candidate[] = [];
   const followDirection = process.currentStep.followDirection;
-  const predsBF = process.curPredsBranchFactor();
+  const predsDirection = process.curPredsDirection();
 
   const namedNodeTriples = triples
     .filter((t): t is NamedNodeTripleDocument => isNamedNode(t))
@@ -395,7 +395,7 @@ function collectNamedNodeCandidates(
       (t) =>
         this.isExtensionValid(t, urlHead) &&
         this.isExtensionAllowed(t, process.currentStep) &&
-        t.directionOk(urlHead.url, followDirection, predsBF)
+        t.directionOk(urlHead.url, followDirection, predsDirection)
     );
 
   for (const t of namedNodeTriples) {

--- a/models/src/Path/Path.ts
+++ b/models/src/Path/Path.ts
@@ -12,7 +12,6 @@ import {
   Severity,
   modelOptions,
   getModelForClass,
-  index,
   type DocumentType
 } from '@typegoose/typegoose';
 import { TraversalPathClass, type TraversalPathSkeleton } from './TraversalPath';
@@ -93,12 +92,6 @@ export type PathSkeletonConstructor<T extends PathSkeleton> = Omit<T, '_id'> & {
 
 export { ResourceCount, SeedClass };
 
-// For counting paths by process, status, head type, and domain origin
-// (used by hasPathsDomainRobotsChecking and hasPathsHeadBeingCrawled)
-@index(
-  { processId: 1, status: 1, 'head.type': 1, 'head.domain.origin': 1 },
-  { name: 'idx_path_base_process_status_head_domain' }
-)
 @modelOptions({
   schemaOptions: {
     discriminatorKey: 'type',

--- a/models/src/Path/Path.ts
+++ b/models/src/Path/Path.ts
@@ -12,6 +12,7 @@ import {
   Severity,
   modelOptions,
   getModelForClass,
+  index,
   type DocumentType
 } from '@typegoose/typegoose';
 import { TraversalPathClass, type TraversalPathSkeleton } from './TraversalPath';
@@ -92,6 +93,9 @@ export type PathSkeletonConstructor<T extends PathSkeleton> = Omit<T, '_id'> & {
 
 export { ResourceCount, SeedClass };
 
+// For counting paths by process, status, head type, and domain origin
+// (used by hasPathsDomainRobotsChecking and hasPathsHeadBeingCrawled)
+@index({ processId: 1, status: 1, 'head.type': 1, 'head.domain.origin': 1 })
 @modelOptions({
   schemaOptions: {
     discriminatorKey: 'type',

--- a/models/src/Path/Path.ts
+++ b/models/src/Path/Path.ts
@@ -95,7 +95,10 @@ export { ResourceCount, SeedClass };
 
 // For counting paths by process, status, head type, and domain origin
 // (used by hasPathsDomainRobotsChecking and hasPathsHeadBeingCrawled)
-@index({ processId: 1, status: 1, 'head.type': 1, 'head.domain.origin': 1 })
+@index(
+  { processId: 1, status: 1, 'head.type': 1, 'head.domain.origin': 1 },
+  { name: 'idx_path_base_process_status_head_domain' }
+)
 @modelOptions({
   schemaOptions: {
     discriminatorKey: 'type',

--- a/models/src/Path/TraversalPath.test.ts
+++ b/models/src/Path/TraversalPath.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TraversalPathClass } from './TraversalPath';
-import {
-  StepClass,
-  PredicateLimitationClass,
-  BranchFactorClass,
-  PredLimitation
-} from '../Process/aux-classes';
+import { StepClass, PredicateLimitationClass, PredLimitation } from '../Process/aux-classes';
 import { buildLimsByType } from '../Process';
 import { Head } from './Path';
 import { Triple } from '../Triple/Triple';
@@ -18,6 +13,11 @@ const LITERAL_PREDS = [
   'http://www.w3.org/2000/01/rdf-schema#label',
   'http://www.w3.org/2000/01/rdf-schema#comment'
 ];
+
+const makeDir = (direction: 'subject' | 'object' | 'none') => ({
+  direction,
+  ratio: 1
+});
 
 describe('TraversalPathClass.genExistingTriplesFilter', () => {
   const createMockPath = (overrides: {
@@ -73,7 +73,7 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       });
     });
 
-    describe('when predsDirMetrics is empty', () => {
+    describe('when predsDirection is empty', () => {
       it('returns empty filter', () => {
         const path = createMockPath();
         const result = path.genDirectionFilter(
@@ -102,19 +102,15 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     });
 
     describe('when predicates have directionality', () => {
-      it('adds predicates to subjPreds when bfRatio >= 1.2', () => {
+      it('adds predicates to subjPreds when direction is subject', () => {
         const path = createMockPath('http://head.org');
-
-        const bf = new BranchFactorClass();
-        bf.subj = 3;
-        bf.obj = 2;
 
         const result = path.genDirectionFilter(
           new Set(),
           new Set(),
           'blacklist',
           true,
-          new Map([['p1', bf]])
+          new Map([['p1', makeDir('subject')]])
         );
 
         expect(result).toHaveProperty('$or');
@@ -123,19 +119,15 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
         expect(result.$or).toContainEqual({ predicate: { $nin: LITERAL_PREDS } });
       });
 
-      it('adds predicates to objPreds when bfRatio <= 0.83', () => {
+      it('adds predicates to objPreds when direction is object', () => {
         const path = createMockPath('http://head.org');
-
-        const bf = new BranchFactorClass();
-        bf.subj = 1;
-        bf.obj = 2;
 
         const result = path.genDirectionFilter(
           new Set(),
           new Set(),
           'blacklist',
           true,
-          new Map([['p1', bf]])
+          new Map([['p1', makeDir('object')]])
         );
 
         expect(result).toHaveProperty('$or');
@@ -144,19 +136,15 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
         expect(result.$or).toContainEqual({ predicate: { $nin: LITERAL_PREDS } });
       });
 
-      it('adds predicates to noDirPreds when bfRatio is between 0.83 and 1.2 (uses $ne for blacklist)', () => {
+      it('adds predicates to noDirPreds when direction is none (uses $ne for blacklist)', () => {
         const path = createMockPath();
-
-        const bf = new BranchFactorClass();
-        bf.subj = 1;
-        bf.obj = 1;
 
         const result = path.genDirectionFilter(
           new Set(),
           new Set(),
           'blacklist',
           true,
-          new Map([['p1', bf]])
+          new Map([['p1', makeDir('none')]])
         );
 
         expect(result).toEqual({ predicate: { $nin: ['p1', ...LITERAL_PREDS] } });
@@ -167,18 +155,14 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('skips predicates not in allowed set', () => {
         const path = createMockPath();
 
-        const bf = new BranchFactorClass();
-        bf.subj = 3;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(['allowed-p1']),
           new Set(),
           'blacklist',
           true,
           new Map([
-            ['allowed-p1', bf],
-            ['not-allowed-p2', bf]
+            ['allowed-p1', makeDir('subject')],
+            ['not-allowed-p2', makeDir('subject')]
           ])
         );
 
@@ -194,18 +178,14 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('skips predicates in notAllowed set', () => {
         const path = createMockPath();
 
-        const bf = new BranchFactorClass();
-        bf.subj = 3;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(),
           new Set(['blocked-p1']),
           'blacklist',
           true,
           new Map([
-            ['blocked-p1', bf],
-            ['allowed-p2', bf]
+            ['blocked-p1', makeDir('subject')],
+            ['allowed-p2', makeDir('subject')]
           ])
         );
 
@@ -221,16 +201,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('adds allowed predicates without metrics to noDirPreds', () => {
         const path = createMockPath();
 
-        const bf = new BranchFactorClass();
-        bf.subj = 3;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(['p1', 'p2']),
           new Set(),
           'blacklist',
           true,
-          new Map([['p1', bf]])
+          new Map([['p1', makeDir('subject')]])
         );
 
         expect(result).toHaveProperty('$or');
@@ -241,16 +217,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('uses direct equality for noDirPreds when limType is whitelist', () => {
         const path = createMockPath();
 
-        const bf = new BranchFactorClass();
-        bf.subj = 1;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(),
           new Set(),
           'whitelist',
           true,
-          new Map([['p1', bf]])
+          new Map([['p1', makeDir('none')]])
         );
 
         expect(result).toHaveProperty('predicate');
@@ -260,16 +232,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('uses $ne for noDirPreds when limType is blacklist', () => {
         const path = createMockPath();
 
-        const bf = new BranchFactorClass();
-        bf.subj = 1;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(),
           new Set(),
           'blacklist',
           true,
-          new Map([['p1', bf]])
+          new Map([['p1', makeDir('none')]])
         );
 
         expect(result).toHaveProperty('predicate', { $nin: ['p1', ...LITERAL_PREDS] });
@@ -280,16 +248,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('uses direct equality for single predicate in subjPreds', () => {
         const path = createMockPath('http://head.org');
 
-        const bf = new BranchFactorClass();
-        bf.subj = 3;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(),
           new Set(),
           'blacklist',
           true,
-          new Map([['p1', bf]])
+          new Map([['p1', makeDir('subject')]])
         );
 
         expect(result).toHaveProperty('$or');
@@ -301,18 +265,14 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('uses $in for multiple predicates in subjPreds', () => {
         const path = createMockPath('http://head.org');
 
-        const bf = new BranchFactorClass();
-        bf.subj = 3;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(),
           new Set(),
           'blacklist',
           true,
           new Map([
-            ['p1', bf],
-            ['p2', bf]
+            ['p1', makeDir('subject')],
+            ['p2', makeDir('subject')]
           ])
         );
 
@@ -330,16 +290,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
       it('returns filter with notAllowed predicate when no predicates pass filters', () => {
         const path = createMockPath();
 
-        const bf = new BranchFactorClass();
-        bf.subj = 3;
-        bf.obj = 1;
-
         const result = path.genDirectionFilter(
           new Set(['allowed-p1']),
           new Set(),
           'blacklist',
           true,
-          new Map([['other-p2', bf]])
+          new Map([['other-p2', makeDir('subject')]])
         );
 
         expect(result).toEqual({ predicate: { $nin: ['allowed-p1', ...LITERAL_PREDS] } });
@@ -349,16 +305,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns single clause without $or when only one predicate set has items', () => {
       const path = createMockPath('http://head.org');
 
-      const bf = new BranchFactorClass();
-      bf.subj = 3;
-      bf.obj = 1;
-
       const result = path.genDirectionFilter(
         new Set(),
         new Set(),
         'blacklist',
         true,
-        new Map([['p1', bf]])
+        new Map([['p1', makeDir('subject')]])
       );
 
       expect(result).toHaveProperty('$or');
@@ -378,16 +330,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns single clause without $or when only subjPreds has items', () => {
       const path = createMockPath({ headUrl: 'http://head.org' });
 
-      const bf = new BranchFactorClass();
-      bf.subj = 3;
-      bf.obj = 1;
-
       const result = path.genDirectionFilter(
         new Set(),
         new Set(),
         'blacklist',
         true,
-        new Map([['p1', bf]])
+        new Map([['p1', makeDir('subject')]])
       );
 
       expect(result).toHaveProperty('$or');
@@ -397,22 +345,14 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns $or when both subjPreds and objPreds have items', () => {
       const path = createMockPath({ headUrl: 'http://head.org' });
 
-      const bfSubj = new BranchFactorClass();
-      bfSubj.subj = 3;
-      bfSubj.obj = 1;
-
-      const bfObj = new BranchFactorClass();
-      bfObj.subj = 1;
-      bfObj.obj = 3;
-
       const result = path.genDirectionFilter(
         new Set(),
         new Set(),
         'blacklist',
         true,
         new Map([
-          ['subj-pred', bfSubj],
-          ['obj-pred', bfObj]
+          ['subj-pred', makeDir('subject')],
+          ['obj-pred', makeDir('object')]
         ])
       );
 
@@ -423,22 +363,14 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns $or when subjPreds and noDirPreds have items', () => {
       const path = createMockPath({ headUrl: 'http://head.org' });
 
-      const bfSubj = new BranchFactorClass();
-      bfSubj.subj = 3;
-      bfSubj.obj = 1;
-
-      const bfNoDir = new BranchFactorClass();
-      bfNoDir.subj = 1;
-      bfNoDir.obj = 1;
-
       const result = path.genDirectionFilter(
         new Set(),
         new Set(),
         'blacklist',
         true,
         new Map([
-          ['subj-pred', bfSubj],
-          ['nodir-pred', bfNoDir]
+          ['subj-pred', makeDir('subject')],
+          ['nodir-pred', makeDir('none')]
         ])
       );
 
@@ -449,22 +381,14 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns $or when objPreds and noDirPreds have items', () => {
       const path = createMockPath({ headUrl: 'http://head.org' });
 
-      const bfObj = new BranchFactorClass();
-      bfObj.subj = 1;
-      bfObj.obj = 3;
-
-      const bfNoDir = new BranchFactorClass();
-      bfNoDir.subj = 1;
-      bfNoDir.obj = 1;
-
       const result = path.genDirectionFilter(
         new Set(),
         new Set(),
         'blacklist',
         true,
         new Map([
-          ['obj-pred', bfObj],
-          ['nodir-pred', bfNoDir]
+          ['obj-pred', makeDir('object')],
+          ['nodir-pred', makeDir('none')]
         ])
       );
 
@@ -475,27 +399,15 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns $or when all three predicate sets have items', () => {
       const path = createMockPath({ headUrl: 'http://head.org' });
 
-      const bfSubj = new BranchFactorClass();
-      bfSubj.subj = 3;
-      bfSubj.obj = 1;
-
-      const bfObj = new BranchFactorClass();
-      bfObj.subj = 1;
-      bfObj.obj = 3;
-
-      const bfNoDir = new BranchFactorClass();
-      bfNoDir.subj = 1;
-      bfNoDir.obj = 1;
-
       const result = path.genDirectionFilter(
         new Set(),
         new Set(),
         'blacklist',
         true,
         new Map([
-          ['subj-pred', bfSubj],
-          ['obj-pred', bfObj],
-          ['nodir-pred', bfNoDir]
+          ['subj-pred', makeDir('subject')],
+          ['obj-pred', makeDir('object')],
+          ['nodir-pred', makeDir('none')]
         ])
       );
 
@@ -506,16 +418,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns filter with $ne when allowed predicate not in predsDirMetrics (added to noDirPreds)', () => {
       const path = createMockPath({ headUrl: 'http://example.com/head' });
 
-      const bf = new BranchFactorClass();
-      bf.subj = 3;
-      bf.obj = 1;
-
       const result = path.genDirectionFilter(
         new Set(['only-allowed']),
         new Set(),
         'blacklist',
         true,
-        new Map([['other-pred', bf]])
+        new Map([['other-pred', makeDir('subject')]])
       );
 
       expect(result).toEqual({ predicate: { $nin: ['only-allowed', ...LITERAL_PREDS] } });
@@ -524,16 +432,12 @@ describe('TraversalPathClass.genExistingTriplesFilter', () => {
     it('returns empty object when all preds filtered out by notAllowed', () => {
       const path = createMockPath({ headUrl: 'http://example.com/head' });
 
-      const bf = new BranchFactorClass();
-      bf.subj = 3;
-      bf.obj = 1;
-
       const result = path.genDirectionFilter(
         new Set(),
         new Set(['blocked-pred']),
         'blacklist',
         true,
-        new Map([['blocked-pred', bf]])
+        new Map([['blocked-pred', makeDir('subject')]])
       );
 
       expect(result).toEqual({ predicate: { $nin: LITERAL_PREDS } });
@@ -1237,7 +1141,7 @@ describe('TraversalPathClass blank node extension', () => {
           maxPathLength: 10,
           maxPathProps: 5
         },
-        curPredsBranchFactor: () => new Map()
+        curPredsDirection: () => new Map()
       };
 
       const result = await path.genExtendedPaths(process, [blankNodeTriple]);
@@ -1298,7 +1202,7 @@ describe('TraversalPathClass.genExtendedPaths ObjectId filter', () => {
         maxPathLength: 10,
         maxPathProps: 5
       },
-      curPredsBranchFactor: () => new Map()
+      curPredsDirection: () => new Map()
     };
 
     // Pass the triple directly (as happens in post-crawl processing)

--- a/models/src/Path/TraversalPath.ts
+++ b/models/src/Path/TraversalPath.ts
@@ -124,6 +124,13 @@ type RecursivePartial<T> = {
   'nodes.count': 1,
   'predicates.count': 1
 })
+@index(
+  { processId: 1, status: 1, 'head.type': 1, 'head.domain.origin': 1 },
+  {
+    name: 'idx_traversal_process_status_head_domain',
+    partialFilterExpression: { type: 'traversal' }
+  }
+)
 @index({ 'head.status': 1, status: 1 }, { name: 'idx_traversal_head_status' })
 @index({ type: 1, 'head.domain.origin': 1, status: 1 }, { name: 'idx_traversal_domain_status' })
 @index({ processId: 1, 'head.url': 1 }, { name: 'idx_traversal_process_url' })

--- a/models/src/Path/TraversalPath.ts
+++ b/models/src/Path/TraversalPath.ts
@@ -268,7 +268,13 @@ export class TraversalPathClass extends PathClass {
 
       extendedPaths[prop] = extendedPaths[prop] || {};
       if (!extendedPaths[prop][newHeadUrl] && !this.tripleIsOutOfBounds(t, process)) {
-        const domain = new URL(newHeadUrl).origin;
+        let domain: string;
+        try {
+          domain = new URL(newHeadUrl).origin;
+        } catch {
+          log.silly(`Skipping invalid URL for path extension: ${newHeadUrl}`);
+          continue;
+        }
         const ep = this.copy();
         const head: Head = {
           type: HEAD_TYPE.URL,

--- a/models/src/Path/TraversalPath.ts
+++ b/models/src/Path/TraversalPath.ts
@@ -90,6 +90,8 @@ type RecursivePartial<T> = {
 @index({ createdAt: 1, _id: 1 })
 // Base indexes
 @index({ type: 1 }, { name: 'idx_traversal_type' })
+// For finding the most recently updated traversal path
+@index({ type: 1, updatedAt: -1 })
 // For the predicates count/elems filtering
 @index({ 'predicates.count': 1, processId: 1, status: 1 })
 @index({ 'nodes.count': 1, processId: 1, status: 1 })

--- a/models/src/Path/TraversalPath.ts
+++ b/models/src/Path/TraversalPath.ts
@@ -21,7 +21,6 @@ import {
 } from '../Triple';
 import { iterateBlankNodeOutgoings } from './blank-node-utils';
 import {
-  BranchFactorClass,
   buildLimsByType,
   type LimsByType,
   matchesAny,
@@ -36,9 +35,8 @@ import { PathClass, Path, ResourceCount, HEAD_TYPE, UrlHead, type Head, SeedClas
 import { PathType, TripleType, type TypedTripleId, isBlankNodeId } from '@derzis/common';
 import { createLogger } from '@derzis/common/server';
 import type { ExtendedPathsResult } from '../types';
-const log = createLogger('TraversalPath');
 import config from '@derzis/config';
-const bfNeutralZone = config.manager.predicates.branchingFactor.neutralZone;
+const log = createLogger('TraversalPath');
 
 export const countNonBlankNodes = (elems: string[]): number =>
   elems.filter((n) => !isBlankNodeId(n)).length;
@@ -247,7 +245,7 @@ export class TraversalPathClass extends PathClass {
     const urlHead = this.head;
     let extendedPaths: { [prop: string]: { [newHead: string]: TraversalPathSkeleton } } = {};
     let procTriples: TypedTripleId[] = [];
-    const predsBF = process.curPredsBranchFactor();
+    const predsDirection = process.curPredsDirection();
     const followDirection = process.currentStep.followDirection;
 
     // Named node triples
@@ -257,7 +255,7 @@ export class TraversalPathClass extends PathClass {
         (t) =>
           this.isExtensionValid(t) &&
           this.isExtensionAllowed(t, process.currentStep) &&
-          t.directionOk(urlHead.url, followDirection, predsBF)
+          t.directionOk(urlHead.url, followDirection, predsDirection)
       );
 
     for (const t of namedNodeTriples) {
@@ -305,7 +303,7 @@ export class TraversalPathClass extends PathClass {
 
         if (!this.isExtensionValid(outgoing)) continue;
         if (!this.isExtensionAllowed(outgoing, process.currentStep)) continue;
-        if (!outgoing.directionOk(urlHead.url, followDirection, predsBF)) continue;
+        if (!outgoing.directionOk(urlHead.url, followDirection, predsDirection)) continue;
 
         const newHeadUrl: string =
           outgoing.subject === blankNodeId ? outgoing.object : outgoing.subject;
@@ -671,7 +669,7 @@ export class TraversalPathClass extends PathClass {
     notAllowed: Set<string>,
     limType: string,
     followDirection: boolean,
-    predsBF: Map<string, BranchFactorClass> | undefined
+    predsDirection: Map<string, { direction: 'subject' | 'object' | 'none' }> | undefined
   ): QueryFilter<NamedNodeTripleDocument> {
     if (!isUrlHead(this.head)) {
       return {};
@@ -679,7 +677,7 @@ export class TraversalPathClass extends PathClass {
 
     const urlHead = this.head;
 
-    if (!followDirection || !predsBF || predsBF.size === 0) {
+    if (!followDirection || !predsDirection || predsDirection.size === 0) {
       return {};
     }
 
@@ -687,7 +685,7 @@ export class TraversalPathClass extends PathClass {
     const objPreds = new Set<string>();
     const noDirPreds = new Set<string>();
 
-    for (const [pred, bf] of predsBF) {
+    for (const [pred, dir] of predsDirection) {
       if (allowed.size && !allowed.has(pred)) {
         continue;
       }
@@ -695,10 +693,9 @@ export class TraversalPathClass extends PathClass {
         continue;
       }
 
-      const bfRatio = bf.subj / bf.obj;
-      if (bfRatio >= bfNeutralZone.max) {
+      if (dir.direction === 'subject') {
         subjPreds.add(pred);
-      } else if (bfRatio <= bfNeutralZone.min) {
+      } else if (dir.direction === 'object') {
         objPreds.add(pred);
       } else {
         noDirPreds.add(pred);
@@ -706,7 +703,7 @@ export class TraversalPathClass extends PathClass {
     }
 
     for (const p of allowed) {
-      if (!predsBF.has(p)) {
+      if (!predsDirection.has(p)) {
         noDirPreds.add(p);
       }
     }
@@ -789,7 +786,7 @@ export class TraversalPathClass extends PathClass {
     const limType = hasRequireFuture ? 'whitelist' : 'blacklist';
 
     const followDirection = process.currentStep.followDirection;
-    const predsBF = process.curPredsBranchFactor();
+    const predsDirection = process.curPredsDirection();
 
     // filter based on directionality metrics
     const directionFilter = this.genDirectionFilter(
@@ -797,7 +794,7 @@ export class TraversalPathClass extends PathClass {
       notAllowed,
       limType,
       followDirection,
-      predsBF
+      predsDirection
     );
 
     const baseFilter: QueryFilter<NamedNodeTripleDocument> = {

--- a/models/src/Path/TraversalPath.ts
+++ b/models/src/Path/TraversalPath.ts
@@ -113,15 +113,16 @@ type RecursivePartial<T> = {
   'nodes.count': 1,
   'predicates.count': 1
 })
-// Optimized index for complex path query in getPathsForDomainCrawl
-// Supports filters: processId, status, head.type, head.domain.isUnvisited, head.status, nodes.count
+// Optimized index for complex path query in getPathsForDomainCrawl and genTraversalPathQuery
+// Supports filters: processId, status, head.type, head.domain.isUnvisited, head.status, nodes.count, predicates.count
 @index({
   processId: 1,
   status: 1,
   'head.type': 1,
   'head.domain.isUnvisited': 1,
   'head.status': 1,
-  'nodes.count': 1
+  'nodes.count': 1,
+  'predicates.count': 1
 })
 @index({ 'head.status': 1, status: 1 }, { name: 'idx_traversal_head_status' })
 @index({ type: 1, 'head.domain.origin': 1, status: 1 }, { name: 'idx_traversal_domain_status' })

--- a/models/src/Process/Process.ts
+++ b/models/src/Process/Process.ts
@@ -536,10 +536,16 @@ class ProcessClass extends Document {
    * Mark the process as done and notify
    */
   public async done() {
-    if (this.status === 'done') {
+    // Atomically claim the done transition — only one concurrent caller succeeds
+    const result = await Process.findOneAndUpdate(
+      { pid: this.pid, status: { $ne: 'done' } },
+      { $set: { status: 'done' } }
+    );
+    if (!result) {
       log.warn(`Process ${this.pid} is already marked as done`);
       return;
     }
+
     this.status = 'done';
     // Counter is already tracked incrementally via ProcessDoneResource - no aggregation needed!
     // Just ensure it's initialized if undefined/null

--- a/models/src/Process/Process.ts
+++ b/models/src/Process/Process.ts
@@ -57,10 +57,10 @@ import {
   getAllResources,
   getAllDomains,
   getInfo,
-  curPredsBranchFactor,
+  curPredsDirection,
   getDoneResourceCount
 } from './process-data';
-import { BranchFactorClass, NotificationClass, StepClass } from './aux-classes';
+import { PredDirection, NotificationClass, StepClass } from './aux-classes';
 import { type SimpleTriple, PathType } from '@derzis/common';
 
 @index({ status: 1 })
@@ -389,8 +389,8 @@ class ProcessClass extends Document {
    * Get predicates branching factor for the current step as a map
    * @returns {Map<string, number> | undefined} - map of predicate URL to branching factor
    */
-  public curPredsBranchFactor(): Map<string, BranchFactorClass> | undefined {
-    return curPredsBranchFactor(this);
+  public curPredsDirection(): Map<string, PredDirection> | undefined {
+    return curPredsDirection(this);
   }
 
   public async getResourceCount(): Promise<number> {

--- a/models/src/Process/aux-classes.ts
+++ b/models/src/Process/aux-classes.ts
@@ -17,6 +17,17 @@ export class PredBranchFactor {
   public branchFactor?: BranchFactorClass;
 }
 
+export class PredDirection {
+  @prop({ type: String })
+  public url!: string;
+
+  @prop({ enum: ['subject', 'object', 'none'], required: true, type: String })
+  public direction!: 'subject' | 'object' | 'none';
+
+  @prop({ type: Number })
+  public ratio!: number;
+}
+
 export class NotificationClass {
   _id?: Types.ObjectId | string;
 
@@ -117,6 +128,12 @@ export class StepClass {
   public predsBranchFactor?: PredBranchFactor[];
 
   /**
+   * Directionality of predicates for this step
+   */
+  @prop({ type: [PredDirection] }, PropType.ARRAY)
+  public predsDirection?: PredDirection[];
+
+  /**
    * Whether to crawl taking into account predicates branch factor
    */
   @prop({ type: Boolean, default: false, required: true })
@@ -162,6 +179,11 @@ export class StepClass {
         branchFactor: pbf.branchFactor
           ? { subj: pbf.branchFactor.subj, obj: pbf.branchFactor.obj }
           : undefined
+      })),
+      predsDirection: this.predsDirection?.map((pd) => ({
+        url: pd.url,
+        direction: pd.direction,
+        ratio: pd.ratio
       })),
       followDirection: this.followDirection,
       resetErrors: this.resetErrors,

--- a/models/src/Process/aux-classes.ts
+++ b/models/src/Process/aux-classes.ts
@@ -92,6 +92,12 @@ export class StepClass {
   _id?: Types.ObjectId | string;
 
   /**
+   * Date when this step was created
+   */
+  @prop({ type: Date, default: () => new Date() })
+  public createdAt?: Date;
+
+  /**
    * Seed URLs to start crawling from
    */
   @prop({ required: true, type: String }, PropType.ARRAY)
@@ -161,6 +167,7 @@ export class StepClass {
 
   public toObject?(): object {
     return {
+      createdAt: this.createdAt,
       seeds: this.seeds,
       maxPathLength: this.maxPathLength,
       maxPathProps: this.maxPathProps,

--- a/models/src/Process/process-crawl-rate.test.ts
+++ b/models/src/Process/process-crawl-rate.test.ts
@@ -1,23 +1,10 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getCrawlRate } from './process-data';
-import { ProcessDoneResource } from '../ProcessDoneResource';
 import { Resource } from '../Resource';
 
-vi.mock('../ProcessDoneResource', () => {
-  const mockLean = vi.fn();
-  const mockFind = vi.fn(() => ({ lean: mockLean }));
-  return {
-    ProcessDoneResource: { find: mockFind },
-    __mockFind: mockFind,
-    __mockLean: mockLean
-  };
-});
-
 vi.mock('../Resource', () => ({
-  Resource: {
-    countDocuments: vi.fn()
-  }
+  Resource: { aggregate: vi.fn() }
 }));
 
 describe('getCrawlRate', () => {
@@ -33,12 +20,7 @@ describe('getCrawlRate', () => {
   });
 
   it('should return crawl rate in resources per minute', async () => {
-    (ProcessDoneResource.find as any)().lean.mockResolvedValue([
-      { resource: 'id1' },
-      { resource: 'id2' },
-      { resource: 'id3' }
-    ]);
-    vi.mocked(Resource.countDocuments).mockResolvedValue(60);
+    vi.mocked(Resource.aggregate).mockResolvedValue([{ count: 60 }]);
 
     const result = await getCrawlRate(mockProcess as any, 5);
 
@@ -46,8 +28,7 @@ describe('getCrawlRate', () => {
   });
 
   it('should return 0 when no resources exist', async () => {
-    (ProcessDoneResource.find as any)().lean.mockResolvedValue([{ resource: 'id1' }]);
-    vi.mocked(Resource.countDocuments).mockResolvedValue(0);
+    vi.mocked(Resource.aggregate).mockResolvedValue([]);
 
     const result = await getCrawlRate(mockProcess as any, 5);
 
@@ -55,7 +36,7 @@ describe('getCrawlRate', () => {
   });
 
   it('should return 0 when no process-done resources tracked', async () => {
-    (ProcessDoneResource.find as any)().lean.mockResolvedValue([]);
+    vi.mocked(Resource.aggregate).mockResolvedValue([]);
 
     const result = await getCrawlRate(mockProcess as any, 5);
 
@@ -63,36 +44,26 @@ describe('getCrawlRate', () => {
   });
 
   it('should use default window of 5 minutes', async () => {
-    (ProcessDoneResource.find as any)().lean.mockResolvedValue([{ resource: 'id1' }]);
-    vi.mocked(Resource.countDocuments).mockResolvedValue(30);
+    vi.mocked(Resource.aggregate).mockResolvedValue([{ count: 30 }]);
 
     const result = await getCrawlRate(mockProcess as any);
 
     expect(result).toBe(6);
   });
 
-  it('should calculate rate based on process ID', async () => {
-    (ProcessDoneResource.find as any)().lean.mockResolvedValue([]);
-
-    await getCrawlRate(mockProcess as any, 5);
-
-    expect(ProcessDoneResource.find).toHaveBeenCalledWith(
-      { processId: 'test-pid-123' },
-      { resource: 1, _id: 0 }
-    );
-  });
-
-  it('should filter resources by status done and updatedAt in window', async () => {
-    (ProcessDoneResource.find as any)().lean.mockResolvedValue([{ resource: 'id1' }]);
-    vi.mocked(Resource.countDocuments).mockResolvedValue(10);
+  it('should pass pipeline with processId, status done, and updatedAt filter', async () => {
+    vi.mocked(Resource.aggregate).mockResolvedValue([{ count: 10 }]);
 
     await getCrawlRate(mockProcess as any, 5);
 
     const cutoffTime = new Date(Date.now() - 5 * 60 * 1000);
-    const countCallArgs = vi.mocked(Resource.countDocuments).mock.calls[0]![0] as any;
-    expect(countCallArgs).toMatchObject({
-      status: 'done'
-    });
-    expect(countCallArgs.updatedAt.$gte.getTime()).toBeCloseTo(cutoffTime.getTime(), -2);
+    const pipeline = vi.mocked(Resource.aggregate).mock.calls[0]![0] as any[];
+
+    expect(pipeline[0].$match).toMatchObject({ status: 'done' });
+    expect(pipeline[0].$match.updatedAt.$gte.getTime()).toBeCloseTo(cutoffTime.getTime(), -2);
+
+    const lookupStage = pipeline[1].$lookup;
+    expect(lookupStage.from).toBe('processDoneResources');
+    expect(lookupStage.pipeline[0].$match.processId).toBe('test-pid-123');
   });
 });

--- a/models/src/Process/process-crawl-rate.test.ts
+++ b/models/src/Process/process-crawl-rate.test.ts
@@ -2,9 +2,20 @@ import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getCrawlRate } from './process-data';
 import { ProcessDoneResource } from '../ProcessDoneResource';
+import { Resource } from '../Resource';
 
-vi.mock('../ProcessDoneResource', () => ({
-  ProcessDoneResource: {
+vi.mock('../ProcessDoneResource', () => {
+  const mockLean = vi.fn();
+  const mockFind = vi.fn(() => ({ lean: mockLean }));
+  return {
+    ProcessDoneResource: { find: mockFind },
+    __mockFind: mockFind,
+    __mockLean: mockLean
+  };
+});
+
+vi.mock('../Resource', () => ({
+  Resource: {
     countDocuments: vi.fn()
   }
 }));
@@ -22,7 +33,12 @@ describe('getCrawlRate', () => {
   });
 
   it('should return crawl rate in resources per minute', async () => {
-    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(60);
+    (ProcessDoneResource.find as any)().lean.mockResolvedValue([
+      { resource: 'id1' },
+      { resource: 'id2' },
+      { resource: 'id3' }
+    ]);
+    vi.mocked(Resource.countDocuments).mockResolvedValue(60);
 
     const result = await getCrawlRate(mockProcess as any, 5);
 
@@ -30,7 +46,16 @@ describe('getCrawlRate', () => {
   });
 
   it('should return 0 when no resources exist', async () => {
-    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(0);
+    (ProcessDoneResource.find as any)().lean.mockResolvedValue([{ resource: 'id1' }]);
+    vi.mocked(Resource.countDocuments).mockResolvedValue(0);
+
+    const result = await getCrawlRate(mockProcess as any, 5);
+
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 when no process-done resources tracked', async () => {
+    (ProcessDoneResource.find as any)().lean.mockResolvedValue([]);
 
     const result = await getCrawlRate(mockProcess as any, 5);
 
@@ -38,7 +63,8 @@ describe('getCrawlRate', () => {
   });
 
   it('should use default window of 5 minutes', async () => {
-    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(30);
+    (ProcessDoneResource.find as any)().lean.mockResolvedValue([{ resource: 'id1' }]);
+    vi.mocked(Resource.countDocuments).mockResolvedValue(30);
 
     const result = await getCrawlRate(mockProcess as any);
 
@@ -46,14 +72,27 @@ describe('getCrawlRate', () => {
   });
 
   it('should calculate rate based on process ID', async () => {
-    vi.mocked(ProcessDoneResource.countDocuments).mockResolvedValue(10);
+    (ProcessDoneResource.find as any)().lean.mockResolvedValue([]);
 
     await getCrawlRate(mockProcess as any, 5);
 
-    expect(ProcessDoneResource.countDocuments).toHaveBeenCalledWith(
-      expect.objectContaining({
-        processId: 'test-pid-123'
-      })
+    expect(ProcessDoneResource.find).toHaveBeenCalledWith(
+      { processId: 'test-pid-123' },
+      { resource: 1, _id: 0 }
     );
+  });
+
+  it('should filter resources by status done and updatedAt in window', async () => {
+    (ProcessDoneResource.find as any)().lean.mockResolvedValue([{ resource: 'id1' }]);
+    vi.mocked(Resource.countDocuments).mockResolvedValue(10);
+
+    await getCrawlRate(mockProcess as any, 5);
+
+    const cutoffTime = new Date(Date.now() - 5 * 60 * 1000);
+    const countCallArgs = vi.mocked(Resource.countDocuments).mock.calls[0]![0] as any;
+    expect(countCallArgs).toMatchObject({
+      status: 'done'
+    });
+    expect(countCallArgs.updatedAt.$gte.getTime()).toBeCloseTo(cutoffTime.getTime(), -2);
   });
 });

--- a/models/src/Process/process-data.ts
+++ b/models/src/Process/process-data.ts
@@ -600,20 +600,21 @@ export async function getCrawlRate(
 ): Promise<number> {
   const cutoffTime = new Date(Date.now() - windowMinutes * 60 * 1000);
 
-  const procResources = await ProcessDoneResource.find(
-    { processId: process.pid },
-    { resource: 1, _id: 0 }
-  ).lean();
-  const resourceIds = procResources.map((pdr) => pdr.resource);
-
-  const count =
-    resourceIds.length > 0
-      ? await Resource.countDocuments({
-          _id: { $in: resourceIds },
-          status: 'done',
-          updatedAt: { $gte: cutoffTime }
-        })
-      : 0;
+  const [result] = await Resource.aggregate<{ count: number }>([
+    { $match: { status: 'done', updatedAt: { $gte: cutoffTime } } },
+    {
+      $lookup: {
+        from: 'processDoneResources',
+        localField: '_id',
+        foreignField: 'resource',
+        pipeline: [{ $match: { processId: process.pid } }, { $limit: 1 }],
+        as: 'pdr'
+      }
+    },
+    { $match: { $expr: { $gt: [{ $size: '$pdr' }, 0] } } },
+    { $count: 'count' }
+  ]);
+  const count = result?.count ?? 0;
 
   return count / windowMinutes;
 }

--- a/models/src/Process/process-data.ts
+++ b/models/src/Process/process-data.ts
@@ -1,5 +1,5 @@
 import { ProcessClass } from './Process';
-import { BranchFactorClass } from './aux-classes';
+import { PredDirection } from './aux-classes';
 import { ProcessTriple } from '../ProcessTriple';
 import { Resource } from '../Resource';
 import { ProcessDoneResource } from '../ProcessDoneResource';
@@ -538,20 +538,30 @@ export async function getInfo(process: ProcessClass) {
   };
 }
 
+const warnedDirectionSteps = new Set<string>();
+
 /**
- * Get predicates branching factor and seed position ratio for the current step as a map
- * @returns {Map<string, number> | undefined} - map of predicate URL to branching factor and seeds position ratio
+ * Get predicates direction for the current step as a map
+ * @returns {Map<string, PredDirection> | undefined} - map of predicate URL to direction metadata
  */
-export function curPredsBranchFactor(
-  process: ProcessClass
-): Map<string, BranchFactorClass> | undefined {
-  return process.currentStep.predsBranchFactor?.reduce((map, obj) => {
-    if (!obj.branchFactor) {
-      return map;
+export function curPredsDirection(process: ProcessClass): Map<string, PredDirection> | undefined {
+  const predsDirection = process.currentStep?.predsDirection;
+  if (!predsDirection || predsDirection.length === 0) {
+    if (process.currentStep?.followDirection) {
+      const stepId =
+        process.currentStep?._id?.toString() || `${process.pid}:${process.steps.length}`;
+      if (!warnedDirectionSteps.has(stepId)) {
+        warnedDirectionSteps.add(stepId);
+        log.warn(`Step ${stepId} has followDirection=true but no predsDirection; allowing all`);
+      }
     }
-    map.set(obj.url, obj.branchFactor);
+    return undefined;
+  }
+
+  return predsDirection.reduce((map, obj) => {
+    map.set(obj.url, obj);
     return map;
-  }, new Map<string, BranchFactorClass>());
+  }, new Map<string, PredDirection>());
 }
 
 export interface PathProgress {

--- a/models/src/Process/process-data.ts
+++ b/models/src/Process/process-data.ts
@@ -600,10 +600,20 @@ export async function getCrawlRate(
 ): Promise<number> {
   const cutoffTime = new Date(Date.now() - windowMinutes * 60 * 1000);
 
-  const count = await ProcessDoneResource.countDocuments({
-    processId: process.pid,
-    createdAt: { $gte: cutoffTime }
-  });
+  const procResources = await ProcessDoneResource.find(
+    { processId: process.pid },
+    { resource: 1, _id: 0 }
+  ).lean();
+  const resourceIds = procResources.map((pdr) => pdr.resource);
+
+  const count =
+    resourceIds.length > 0
+      ? await Resource.countDocuments({
+          _id: { $in: resourceIds },
+          status: 'done',
+          updatedAt: { $gte: cutoffTime }
+        })
+      : 0;
 
   return count / windowMinutes;
 }

--- a/models/src/Process/process-paths.test.ts
+++ b/models/src/Process/process-paths.test.ts
@@ -321,7 +321,7 @@ describe('genTraversalPathQuery', () => {
       pathType: 'traversal' | 'endpoint' = 'traversal'
     ): ProcessClass => ({
       pid,
-      config: { manager: { pathType } }
+      curPathType: pathType
     });
 
     beforeEach(() => {
@@ -343,6 +343,7 @@ describe('genTraversalPathQuery', () => {
       expect(Path.countDocuments).toHaveBeenCalledWith({
         processId: 'pid-1',
         status: 'active',
+        type: 'endpoint',
         'head.type': 'url',
         'head.domain.origin': { $in: mockDomains.map((d) => d.origin) }
       });
@@ -388,7 +389,7 @@ describe('genTraversalPathQuery', () => {
       pathType: 'traversal' | 'endpoint' = 'traversal'
     ): ProcessClass => ({
       pid,
-      config: { manager: { pathType } }
+      curPathType: pathType
     });
 
     beforeEach(() => {
@@ -410,6 +411,7 @@ describe('genTraversalPathQuery', () => {
       expect(Path.countDocuments).toHaveBeenCalledWith({
         processId: 'pid-1',
         status: 'active',
+        type: 'endpoint',
         'head.type': HEAD_TYPE.URL,
         'head.domain.origin': { $in: mockCrawlingDomains.map((d) => d.origin) }
       });
@@ -424,6 +426,7 @@ describe('genTraversalPathQuery', () => {
       expect(Path.countDocuments).toHaveBeenCalledWith({
         processId: 'pid-2',
         status: 'active',
+        type: 'traversal',
         'head.type': HEAD_TYPE.URL,
         'head.domain.origin': { $in: mockCrawlingDomains.map((d) => d.origin) }
       });

--- a/models/src/Process/process-paths.ts
+++ b/models/src/Process/process-paths.ts
@@ -1061,16 +1061,18 @@ async function insertProcDoneRes(pid: string, procTriples: TypedTripleId[]) {
   }
 
   // Create ProcessDoneResource records (track process-resource relationships)
-  const processDoneResources = resources.map((r) => ({
-    processId: pid,
-    resource: r._id
-  }));
+  const processDoneResources: { processId: string; resource: Types.ObjectId }[] = resources.map(
+    (r) => ({
+      processId: pid,
+      resource: r._id
+    })
+  );
 
   if (processDoneResources.length > 0) {
-    await ProcessDoneResource.bulkWrite(
+    await ProcessDoneResource.collection.bulkWrite(
       processDoneResources.map((p) => ({
         updateOne: {
-          filter: { processId: p.processId, resource: p.resource },
+          filter: p,
           update: { $setOnInsert: p },
           upsert: true
         }

--- a/models/src/Process/process-paths.ts
+++ b/models/src/Process/process-paths.ts
@@ -735,11 +735,10 @@ export async function hasPathsDomainRobotsChecking(process: ProcessClass): Promi
     return false;
   }
 
-  // Count how many active paths have head domains that are currently being checked for robots.txt
-  // Using base Path model (all paths for this process are of the same type configured in process)
   const query = {
     processId: process.pid,
     status: 'active',
+    type: process.curPathType,
     'head.type': HEAD_TYPE.URL,
     'head.domain.origin': { $in: domains.map((d) => d.origin) }
   };
@@ -770,6 +769,7 @@ export async function hasPathsHeadBeingCrawled(process: ProcessClass): Promise<b
   const query = {
     processId: process.pid,
     status: 'active',
+    type: process.curPathType,
     'head.type': HEAD_TYPE.URL,
     'head.domain.origin': { $in: domains.map((d) => d.origin) }
   };
@@ -1067,24 +1067,19 @@ async function insertProcDoneRes(pid: string, procTriples: TypedTripleId[]) {
   }));
 
   if (processDoneResources.length > 0) {
-    try {
-      await ProcessDoneResource.insertMany(processDoneResources, {
-        ordered: false // Continue on duplicate key errors
-      });
-      log.debug(
-        `Created ${processDoneResources.length} ProcessDoneResource records for process ${pid}`
-      );
-    } catch (err: any) {
-      if (err.code === 11000) {
-        // Duplicate key errors are expected (resources already tracked)
-        const insertedCount = err.result?.nInserted || 0;
-        log.debug(
-          `Inserted ${insertedCount} new ProcessDoneResource records (${processDoneResources.length - insertedCount} duplicates) for process ${pid}`
-        );
-      } else {
-        throw err;
-      }
-    }
+    await ProcessDoneResource.bulkWrite(
+      processDoneResources.map((p) => ({
+        updateOne: {
+          filter: { processId: p.processId, resource: p.resource },
+          update: { $setOnInsert: p },
+          upsert: true
+        }
+      })),
+      { ordered: false }
+    );
+    log.debug(
+      `Tracked ${processDoneResources.length} ProcessDoneResource records for process ${pid}`
+    );
 
     // Increment counter for resources that are already 'done'
     const doneResourceIds = resources.filter((r) => r.status === 'done').map((r) => r._id);

--- a/models/src/ProcessDoneResource.ts
+++ b/models/src/ProcessDoneResource.ts
@@ -1,6 +1,7 @@
 import { ResourceClass } from './Resource';
 import { prop, index, getModelForClass } from '@typegoose/typegoose';
 
+@index({ resource: 1 })
 @index({ processId: 1, resource: 1 }, { unique: true })
 class ProcessDoneResourceClass {
   @prop({ required: true, type: String })

--- a/models/src/Resource.ts
+++ b/models/src/Resource.ts
@@ -154,12 +154,17 @@ class ResourceClass {
       }
     }
 
-    return await this.addMany(
-      Object.keys(resources).map((u) => ({
-        url: u,
-        domain: new URL(u).origin
-      }))
-    );
+    const validResources: { url: string; domain: string }[] = [];
+    for (const u of Object.keys(resources)) {
+      try {
+        const domain = new URL(u).origin;
+        validResources.push({ url: u, domain });
+      } catch {
+        log.warn(`Skipping invalid URL from triples: ${u}`);
+      }
+    }
+    if (validResources.length === 0) return [];
+    return await this.addMany(validResources);
   }
 
   /**

--- a/models/src/Resource.ts
+++ b/models/src/Resource.ts
@@ -71,6 +71,7 @@ function hasUrlHead<T extends { head: { type: string } }>(p: T): p is T & { head
 @index({ domain: 1, status: 1 })
 @index({ url: 1 }, { unique: true })
 @index({ status: 1 })
+@index({ status: 1, updatedAt: 1 })
 @index({ domain: 1, status: 1, url: 1 })
 class ResourceClass {
   createdAt!: Date;

--- a/models/src/Triple/Triple.test.ts
+++ b/models/src/Triple/Triple.test.ts
@@ -1,39 +1,50 @@
 import { describe, it, expect } from 'vitest';
-import { directionOk, SimpleNamedNodeTriple, TripleType } from '@derzis/common';
+import { NamedNodeTripleClass } from './Triple';
+import type { PredDirection } from '../Process';
 
-describe('directionOk', () => {
-  const triple: SimpleNamedNodeTriple = {
-    subject: 'http://example.com/subject',
-    predicate: 'http://example.com/predicate',
-    object: 'http://example.com/object',
-    type: TripleType.NAMED_NODE
-  };
+describe('NamedNodeTripleClass.directionOk', () => {
+  const triple = new NamedNodeTripleClass();
+  triple.subject = 'http://example.com/subject';
+  triple.predicate = 'http://example.com/predicate';
+  triple.object = 'http://example.com/object';
 
-  it('returns true when branch factor is 1 (no directionality)', () => {
-    expect(directionOk(triple, 'http://example.com/any', 1)).toBe(true);
+  const makeMap = (direction: PredDirection['direction']) =>
+    new Map<string, PredDirection>([
+      [
+        triple.predicate,
+        {
+          url: triple.predicate,
+          direction,
+          ratio: 1
+        }
+      ]
+    ]);
+
+  it('returns true when followDirection is false', () => {
+    expect(triple.directionOk(triple.subject, false, makeMap('subject'))).toBe(true);
   });
 
-  it('returns true when branch factor > 1 and headUrl matches subject', () => {
-    expect(directionOk(triple, triple.subject, 2)).toBe(true);
+  it('returns true when predsDirection is missing', () => {
+    expect(triple.directionOk(triple.subject, true, undefined)).toBe(true);
   });
 
-  it('returns false when branch factor > 1 and headUrl does not match subject', () => {
-    expect(directionOk(triple, 'http://example.com/other', 2)).toBe(false);
+  it('returns true when direction is none', () => {
+    expect(triple.directionOk(triple.subject, true, makeMap('none'))).toBe(true);
   });
 
-  it('returns true when branch factor < 1 and headUrl matches object', () => {
-    expect(directionOk(triple, triple.object, 0.5)).toBe(true);
+  it('returns true when direction is subject and headUrl matches subject', () => {
+    expect(triple.directionOk(triple.subject, true, makeMap('subject'))).toBe(true);
   });
 
-  it('returns false when branch factor < 1 and headUrl does not match object', () => {
-    expect(directionOk(triple, 'http://example.com/other', 0.5)).toBe(false);
+  it('returns false when direction is subject and headUrl matches object', () => {
+    expect(triple.directionOk(triple.object, true, makeMap('subject'))).toBe(false);
   });
 
-  it('returns false when branch factor < 1 and headUrl matches subject instead of object', () => {
-    expect(directionOk(triple, triple.subject, 0.5)).toBe(false);
+  it('returns true when direction is object and headUrl matches object', () => {
+    expect(triple.directionOk(triple.object, true, makeMap('object'))).toBe(true);
   });
 
-  it('returns false when branch factor > 1 and headUrl matches object instead of subject', () => {
-    expect(directionOk(triple, triple.object, 2)).toBe(false);
+  it('returns false when direction is object and headUrl matches subject', () => {
+    expect(triple.directionOk(triple.subject, true, makeMap('object'))).toBe(false);
   });
 });

--- a/models/src/Triple/Triple.ts
+++ b/models/src/Triple/Triple.ts
@@ -11,15 +11,14 @@ import {
   urlValidator,
   urlOrBlankNodeValidator,
   type SimpleTriple,
-  directionOk,
   TripleType,
   type BlankNodeObject
 } from '@derzis/common';
-import config from '@derzis/config';
 import type { BulkWriteResult } from 'mongodb';
 import { createLogger } from '@derzis/common/server';
 import { type DocumentType } from '@typegoose/typegoose/lib/types';
-import { BranchFactorClass } from '../Process';
+import { PredDirection } from '../Process';
+import config from '@derzis/config';
 import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses';
 
 const log = createLogger('Triple');
@@ -245,35 +244,27 @@ export class NamedNodeTripleClass extends TripleClass {
   public directionOk(
     headUrl: string,
     followDirection: boolean,
-    predsBF?: Map<string, BranchFactorClass>
+    predsDirection?: Map<string, PredDirection>
   ): boolean {
     if (!followDirection) {
       return true;
     }
 
-    if (!predsBF || !predsBF.size) {
-      log.warn('Predicate branching factor not provided, cannot enforce directionality');
+    if (!predsDirection || !predsDirection.size) {
+      log.warn('Predicate direction not provided, cannot enforce directionality');
       return true;
     }
 
-    if (!predsBF.has(this.predicate)) {
+    if (!predsDirection.has(this.predicate)) {
       return true;
     }
 
-    const bf = predsBF.get(this.predicate);
-    if (!bf) return true;
-    const bfRatio = bf.subj / bf.obj;
+    const predDirection = predsDirection.get(this.predicate);
+    if (!predDirection) return true;
+    if (predDirection.direction === 'none') return true;
 
-    const dOk = directionOk(
-      {
-        subject: this.subject,
-        predicate: this.predicate,
-        object: this.object,
-        type: TripleType.NAMED_NODE as const
-      },
-      headUrl,
-      bfRatio
-    );
+    const dOk =
+      predDirection.direction === 'subject' ? headUrl === this.subject : headUrl === this.object;
 
     log.silly(
       `Direction ${dOk ? '' : 'not '}ok for head url ${headUrl} and triple ${this.subject} ${this.predicate} ${this.object}`

--- a/models/src/Triple/triple-helper.test.ts
+++ b/models/src/Triple/triple-helper.test.ts
@@ -1,39 +1,76 @@
 import { describe, it, expect } from 'vitest';
-import { directionOk, SimpleNamedNodeTriple, TripleType } from '@derzis/common';
+import { NamedNodeTripleClass } from './Triple';
+import type { PredDirection } from '../Process';
 
-describe('directionOk', () => {
-  const triple: SimpleNamedNodeTriple = {
-    subject: 'http://example.com/subject',
-    predicate: 'http://example.com/predicate',
-    object: 'http://example.com/object',
-    type: TripleType.NAMED_NODE
-  };
+describe('NamedNodeTripleClass.directionOk (via triple-helper pattern)', () => {
+  const triple = new NamedNodeTripleClass();
+  triple.subject = 'http://example.com/subject';
+  triple.predicate = 'http://example.com/predicate';
+  triple.object = 'http://example.com/object';
 
-  it('returns true when branch factor is 1 (no directionality)', () => {
-    expect(directionOk(triple, 'http://example.com/any', 1)).toBe(true);
+  const makeMap = (direction: PredDirection['direction']) =>
+    new Map<string, PredDirection>([
+      [
+        triple.predicate,
+        {
+          url: triple.predicate,
+          direction,
+          ratio: 1
+        }
+      ]
+    ]);
+
+  it('returns true when followDirection is false', () => {
+    expect(triple.directionOk(triple.subject, false, makeMap('subject'))).toBe(true);
   });
 
-  it('returns true when branch factor > 1 and headUrl matches subject', () => {
-    expect(directionOk(triple, triple.subject, 2)).toBe(true);
+  it('returns true when predsDirection is missing', () => {
+    expect(triple.directionOk(triple.subject, true, undefined)).toBe(true);
   });
 
-  it('returns false when branch factor > 1 and headUrl does not match subject', () => {
-    expect(directionOk(triple, 'http://example.com/other', 2)).toBe(false);
+  it('returns true when predsDirection map is empty', () => {
+    expect(triple.directionOk(triple.subject, true, new Map())).toBe(true);
   });
 
-  it('returns true when branch factor < 1 and headUrl matches object', () => {
-    expect(directionOk(triple, triple.object, 0.5)).toBe(true);
+  it('returns true when direction is none', () => {
+    expect(triple.directionOk(triple.subject, true, makeMap('none'))).toBe(true);
   });
 
-  it('returns false when branch factor < 1 and headUrl does not match object', () => {
-    expect(directionOk(triple, 'http://example.com/other', 0.5)).toBe(false);
+  it('returns true when direction is subject and headUrl matches subject', () => {
+    expect(triple.directionOk(triple.subject, true, makeMap('subject'))).toBe(true);
   });
 
-  it('returns false when branch factor < 1 and headUrl matches subject instead of object', () => {
-    expect(directionOk(triple, triple.subject, 0.5)).toBe(false);
+  it('returns false when direction is subject and headUrl matches object', () => {
+    expect(triple.directionOk(triple.object, true, makeMap('subject'))).toBe(false);
   });
 
-  it('returns false when branch factor > 1 and headUrl matches object instead of subject', () => {
-    expect(directionOk(triple, triple.object, 2)).toBe(false);
+  it('returns false when direction is subject and headUrl matches other', () => {
+    expect(triple.directionOk('http://example.com/other', true, makeMap('subject'))).toBe(false);
+  });
+
+  it('returns true when direction is object and headUrl matches object', () => {
+    expect(triple.directionOk(triple.object, true, makeMap('object'))).toBe(true);
+  });
+
+  it('returns false when direction is object and headUrl matches subject', () => {
+    expect(triple.directionOk(triple.subject, true, makeMap('object'))).toBe(false);
+  });
+
+  it('returns false when direction is object and headUrl matches other', () => {
+    expect(triple.directionOk('http://example.com/other', true, makeMap('object'))).toBe(false);
+  });
+
+  it('returns true when predicate is not in predsDirection map', () => {
+    const otherMap = new Map<string, PredDirection>([
+      [
+        'http://other/pred',
+        {
+          url: 'http://other/pred',
+          direction: 'subject',
+          ratio: 1
+        }
+      ]
+    ]);
+    expect(triple.directionOk(triple.subject, true, otherMap)).toBe(true);
   });
 });

--- a/worker/src/lib/Worker.ts
+++ b/worker/src/lib/Worker.ts
@@ -27,6 +27,7 @@ import {
   RobotsForbiddenError,
   TooManyRedirectsError,
   WorkerError,
+  isValid,
   type JobType,
   type RobotsCheckResult,
   type CrawlResourceResult,
@@ -600,6 +601,7 @@ export class Worker extends EventEmitter {
         .filter(
           (t) =>
             t.subject?.termType === 'NamedNode' &&
+            isValid(t.subject.value) &&
             t.predicate?.termType === 'NamedNode' &&
             t.object !== undefined &&
             t.object.termType !== undefined &&


### PR DESCRIPTION
## Summary

- **Replaced predicate branch-factor (ratio) directionality with explicit predicate direction.** Steps now carry `predsDirection` (`subject` | `object` | `none` + ratio) instead of `predsBranchFactor`. The `directionOk` logic in `Triple` and `TraversalPath`/`EndpointPath` now uses the explicit direction rather than computing `subj/obj` ratios against a `neutralZone` config, removing a class of silent misdirection bugs. `predsBranchFactor` is rejected by the `add-step` API (HTTP 400) for a clean migration.
- **Hardened the `Process.done()` race condition** with an atomic `findOneAndUpdate({ status: { $ne: 'done' } })` so only one concurrent caller completes the transition.
- **Fixed `ProcessDoneResource` duplicate tracking** by switching from `insertMany` to `bulkWrite` upserts (`$setOnInsert`), avoiding TypeGoose ref typing issues and keeping a single index (`resource: 1`).
- **Added `step.createdAt` tracking** and display it in the process page ("Created" rows) and done-summary alert.
- **Improved SSE live progress reliability** (`events/+server.ts`): non-fatal error recovery with a consecutive-error cap, terminal `PROCESS_DONE`/`PROCESS_ERROR` events, and crawling-style progress fallback when there are no done-head paths to extend (common for endpoint processes).
- **Rewrote the triples `.nt.gz` export** to use `StreamWriter` + a `Transform` quad converter (handles named-node and literal quads), replacing the buggy `Writer` callback stream.
- **Defensive invalid-URL handling**: worker filters invalid URL subjects; `TraversalPath` skips path extensions with malformed URLs; `Resource.addFromTriples` drops invalid URLs; `Manager` unsets worker/job state and marks domains `unvisited` on robots-save errors and parses robots.txt in a try/catch.
- **Added MongoDB indexes** to eliminate COLLSCAN/in-memory sorts: typed partial-filter indexes on `Path` (`idx_traversal_*`/`idx_endpoint_*`), `updatedAt` index on `TraversalPath`, and `status+updatedAt` index on `Resource`. `hasPathsDomainRobotsChecking`/`hasPathsHeadBeingCrawled` now scope by `type` to avoid cross-type matches.
- **Refactored `getCrawlRate`** to use a `$lookup` aggregation against `processDoneResources` instead of a naive `countDocuments`, fixing rate/ETA accuracy.
- Fixed `manager/package.json` env var (`NODE_OPTS` -> `NODE_OPTIONS`) and exported `isValid`/`url` helpers from `@derzis/common`.

## Impact

- **Breaking (API)**: `POST /api/processes/[pid]/add-step` no longer accepts `predsBranchFactor`; send `predsDirection` instead. Old payloads are rejected with 400. Existing stored steps using `predsBranchFactor` are ignored for directionality (all triples allowed when no `predsDirection`).
- **New**: `predsDirection` and `step.createdAt` fields; `PredDirection` class exported from `@derzis/models`; terminal SSE events and endpoint-process progress fallback.
- **Modified**: directionality is now driven by precomputed direction metadata rather than live ratio thresholds, so crawl behavior for `followDirection` steps changes accordingly.
- **Behavior**: `Process.done()` is now idempotent; duplicate resource tracking no longer throws; invalid URLs no longer crash crawl/path extension.

## Notes

- Index changes require a sync (use base `Path` model, not discriminators, per AGENTS.md).
- Tests in `models` were updated/refactored to reflect the new direction model and aggregation-based crawl rate.
- No new external dependencies added.